### PR TITLE
chore: Keep repo in sync

### DIFF
--- a/libsentrykube/libsentrykube/ext.py
+++ b/libsentrykube/libsentrykube/ext.py
@@ -505,7 +505,7 @@ class GeoIPInitContainer(SimpleExtension):
     used as a container inside of pod.spec.initContainers.
     """
 
-    def run(self, image: str = "busybox:1.31"):
+    def run(self, image: str = "busybox:1.36"):
         return json.dumps(
             {
                 "image": image,

--- a/libsentrykube/libsentrykube/iap.py
+++ b/libsentrykube/libsentrykube/iap.py
@@ -102,7 +102,6 @@ def ensure_iap_tunnel(ctx: click.core.Context, quiet: bool = False) -> str:
                     "ExitOnForwardFailure=yes",
                     "-L",
                     port_fwd,
-                    "ssh-key-expire-after=1d",
                 ),
             ),
             # spawn as detached process

--- a/libsentrykube/libsentrykube/ssh.py
+++ b/libsentrykube/libsentrykube/ssh.py
@@ -31,6 +31,7 @@ def build_ssh_command(ctx, host, project, user, ssh_key_file, region, zone, ssh_
         f"{region}-{zone}",
         "--project",
         project,
+        "--ssh-key-expire-after=1d",
     )
     if ssh_key_file:
         cmd += ("--ssh-key-file", ssh_key_file)

--- a/sentry_kube/cli/kafkactl.py
+++ b/sentry_kube/cli/kafkactl.py
@@ -1,5 +1,4 @@
 # sentry-kube
-# --iap
 # -C saas
 # run-pod
 # --exec

--- a/sentry_kube/cli/run_job.py
+++ b/sentry_kube/cli/run_job.py
@@ -40,10 +40,7 @@ def run_job(ctx, job_name, arg, kwarg, service_name, yes, quiet):
             cluster_name,
             # Skip GKE CRDs which don't work with our
             # client-side kubernetes API management
-            skip_kinds=(
-                "BackendConfig",
-                "ManagedCertificate",
-            ),
+            skip_kinds=("BackendConfig", "ManagedCertificate", "VerticalPodAutoscaler"),
             kind_matches=("Job",),
             name_matches=(job_name,),
             extra_args=arg,

--- a/sentry_kube/ext.py
+++ b/sentry_kube/ext.py
@@ -86,13 +86,13 @@ class PGBouncerSidecar(SimpleExtension):
     def run(
         self,
         databases: List[str],
-        repository: str = "mattrobenolt",
+        repository: str = "us.gcr.io/sentryio",
         preStopWait: int = 1,
         checkInterval: int = 1,
         maxClientConn: int = 100,
         defaultPoolSize: int = 25,
         serverLifetime: int = 300,
-        version: str = "1.15.0",
+        version: str = "1.23.1-alpine3.20",
         application_name: Optional[str] = None,
         livenessProbe: Optional[dict] = None,
         resources: Optional[dict] = None,
@@ -138,7 +138,7 @@ cat << EOF > /etc/pgbouncer.ini
 [pgbouncer]
 listen_addr = 0.0.0.0
 listen_port = 6432
-unix_socket_dir ={ " ''" if version == "1.15.0" else "" }
+unix_socket_dir =
 auth_type = trust
 auth_file = /etc/pgbouncer/userlist.txt
 admin_users = postgres


### PR DESCRIPTION
Applying the diff between the revisions 1122b46cc4566cd755d1475511807e9334fd04f9 and c292a414d8ca1cb5c3137b36c54fc03f9ab8b105

The diff in the ops repo was like this
```bash
diff --git a/k8s/cli/libsentrykube/libsentrykube/ext.py b/k8s/cli/libsentrykube/libsentrykube/ext.py
index b73aaa51c..7984343ba 100644
--- a/k8s/cli/libsentrykube/libsentrykube/ext.py
+++ b/k8s/cli/libsentrykube/libsentrykube/ext.py
@@ -505,7 +505,7 @@ class GeoIPInitContainer(SimpleExtension):
     used as a container inside of pod.spec.initContainers.
     """

-    def run(self, image: str = "busybox:1.31"):
+    def run(self, image: str = "busybox:1.36"):
         return json.dumps(
             {
                 "image": image,
diff --git a/k8s/cli/libsentrykube/libsentrykube/iap.py b/k8s/cli/libsentrykube/libsentrykube/iap.py
index a48fcdeb7..f1a3bd408 100644
--- a/k8s/cli/libsentrykube/libsentrykube/iap.py
+++ b/k8s/cli/libsentrykube/libsentrykube/iap.py
@@ -102,7 +102,6 @@ def ensure_iap_tunnel(ctx: click.core.Context, quiet: bool = False) -> str:
                     "ExitOnForwardFailure=yes",
                     "-L",
                     port_fwd,
-                    "ssh-key-expire-after=1d",
                 ),
             ),
             # spawn as detached process
diff --git a/k8s/cli/libsentrykube/libsentrykube/ssh.py b/k8s/cli/libsentrykube/libsentrykube/ssh.py
index aa3113a9f..fea0b77cc 100644
--- a/k8s/cli/libsentrykube/libsentrykube/ssh.py
+++ b/k8s/cli/libsentrykube/libsentrykube/ssh.py
@@ -31,6 +31,7 @@ def build_ssh_command(ctx, host, project, user, ssh_key_file, region, zone, ssh_
         f"{region}-{zone}",
         "--project",
         project,
+        "--ssh-key-expire-after=1d",
     )
     if ssh_key_file:
         cmd += ("--ssh-key-file", ssh_key_file)
diff --git a/k8s/cli/sentry_kube/cli/kafkactl.py b/k8s/cli/sentry_kube/cli/kafkactl.py
index 17d5be17e..82106bd63 100644
--- a/k8s/cli/sentry_kube/cli/kafkactl.py
+++ b/k8s/cli/sentry_kube/cli/kafkactl.py
@@ -1,5 +1,4 @@
 # sentry-kube
-# --iap
 # -C saas
 # run-pod
 # --exec
diff --git a/k8s/cli/sentry_kube/cli/run_job.py b/k8s/cli/sentry_kube/cli/run_job.py
index d998abdb5..55b2f19a3 100644
--- a/k8s/cli/sentry_kube/cli/run_job.py
+++ b/k8s/cli/sentry_kube/cli/run_job.py
@@ -40,10 +40,7 @@ def run_job(ctx, job_name, arg, kwarg, service_name, yes, quiet):
             cluster_name,
             # Skip GKE CRDs which don't work with our
             # client-side kubernetes API management
-            skip_kinds=(
-                "BackendConfig",
-                "ManagedCertificate",
-            ),
+            skip_kinds=("BackendConfig", "ManagedCertificate", "VerticalPodAutoscaler"),
             kind_matches=("Job",),
             name_matches=(job_name,),
             extra_args=arg,
diff --git a/k8s/cli/sentry_kube/ext.py b/k8s/cli/sentry_kube/ext.py
index fe1c52400..e82e9be5c 100644
--- a/k8s/cli/sentry_kube/ext.py
+++ b/k8s/cli/sentry_kube/ext.py
@@ -86,13 +86,13 @@ class PGBouncerSidecar(SimpleExtension):
     def run(
         self,
         databases: List[str],
-        repository: str = "mattrobenolt",
+        repository: str = "us.gcr.io/sentryio",
         preStopWait: int = 1,
         checkInterval: int = 1,
         maxClientConn: int = 100,
         defaultPoolSize: int = 25,
         serverLifetime: int = 300,
-        version: str = "1.15.0",
+        version: str = "1.23.1-alpine3.20",
         application_name: Optional[str] = None,
         livenessProbe: Optional[dict] = None,
         resources: Optional[dict] = None,
@@ -138,7 +138,7 @@ cat << EOF > /etc/pgbouncer.ini
 [pgbouncer]
 listen_addr = 0.0.0.0
 listen_port = 6432
-unix_socket_dir ={ " ''" if version == "1.15.0" else "" }
+unix_socket_dir =
 auth_type = trust
 auth_file = /etc/pgbouncer/userlist.txt
 admin_users = postgres
```