### PR TITLE
fix(python): Reduce minimum python version required to 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,5 @@ setup(
         "libsentrykube.macros": macros,
     },
     scripts=["bin/sentry-kube-pop"],
-    python_requires=">=3.11",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
Addressing the comment mentioned [here](https://github.com/getsentry/pypi/pull/968#issuecomment-2341865629) on minimum python version being 3.10