### PR TITLE
chore(requirements): Fix dependencies based on sentry pypi

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,6 @@ google-auth
 google-api-python-client
 paramiko
 pathspec
-httpx
 requests>=2.32.2
 responses
 sentry_jsonnet

--- a/requirements.txt
+++ b/requirements.txt
@@ -172,15 +172,15 @@ sshuttle==1.1.2
     # via -r requirements.in
 tabulate==0.9.0
     # via -r requirements.in
-types-jsonschema==4.23.0.20240712
+types-jsonschema==4.23.0.20240813
     # via -r requirements.in
 types-paramiko==3.4.0.20240423
     # via -r requirements.in
 types-pyyaml==6.0.12.20240311
     # via -r requirements.in
-types-requests==2.32.0.20240712
+types-requests==2.32.0.20240907
     # via -r requirements.in
-types-setuptools==70.3.0.20240710
+types-setuptools==74.1.0.20240907
     # via -r requirements.in
 types-tabulate==0.9.0.20240106
     # via -r requirements.in


### PR DESCRIPTION
In order for sentry-infra-tools to be published in sentry's pypi, lets use the typing versions already available there.

Deliberately not using the newer versions of other packages in order to inadvertently breaking existing tooling.