### PR TITLE
fix(materialize): Take root directory as argument

### DIFF
--- a/config_builder/generate_topic_data.py
+++ b/config_builder/generate_topic_data.py
@@ -1,13 +1,15 @@
 import os
+import click
 import json
 from sys import stderr
 from sentry_kafka_schemas import get_topic, list_topics
 from pathlib import Path
 
 
-def main() -> None:
-    root = Path(os.path.abspath(__file__)).parent.parent.parent.parent
-    output = f"{root}/shared_config/kafka/topics/generated/_generated_raw_topic_data.json"
+@click.command()
+@click.option("--root-dir", default="", help="Path where the root directory exists")
+def generate_raw_topic_data(root_dir: str) -> None:
+    output = f"{root_dir}/kafka/topics/generated/_generated_raw_topic_data.json"
 
     print("Generating raw topic data", file=stderr)
     file_path = Path(output)
@@ -20,7 +22,3 @@ def main() -> None:
     os.makedirs(file_path.parent, exist_ok=True)
     with open(file_path, "w") as f:
         f.write(json.dumps(topic_data, indent=2) + "\n")
-
-
-if __name__ == "__main__":
-    main()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ macros = [
 
 def get_requirements() -> Sequence[str]:
     with open("requirements.txt") as f:
-        return [x.strip() for x in f.read().split("\n") if not x.startswith(("#", "--"))]
+        return [
+            x.strip() for x in f.read().split("\n") if not x.startswith(("#", "--"))
+        ]
 
 
 setup(
@@ -52,7 +54,7 @@ setup(
         "console_scripts": [
             "sentry-kube=sentry_kube.cli:main",
             "materialize-config=config_builder.materialize_all:main",
-            "generate-raw-topic-data=config_builder.generate_topic_data:main",
+            "generate-raw-topic-data=config_builder.generate_topic_data:generate_raw_topic_data",
             "pr-docs=assistant.prdocs:main",
             "pr-approver=pr_approver.approver:main",
         ],


### PR DESCRIPTION
The generate_raw_topic_data has implicit knowledge of the hierarchy of the directories it works with. This breaks when using sentry infra tools since the tools are installed in different directories. Allow it to take a root directory argument and pass it in the make materialize command of ops repo for integration to work.

# Testing

## Before
```bash
 ~/w/ops  nikhars/fix/..-infra-tools !1 ?1  make materialize
 ok | direnv  .venv-sentry-kube py | 3.11.7  py  14:15:50
generate-raw-topic-data --root-dir ./shared_config
Generating raw topic data
shared_config/shared_config/kafka/topics/generated/_generated_raw_topic_data.json
materialize-config -c -o _materialized_configs --root-dir ./shared_config/
Validating yaml file schemas
Combining individual source files
Materializing jsonnet files
[GENERATED] shared_config/service_registry/combined/service_registry.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/us/us_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/ly/ly_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/geico/geico_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/goldmansachs/goldmansachs_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/de/de_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/disney/disney_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/s4s/s4s_consumer_groups.jsonnet
Jsonnet Error occurred while materializing shared_config/kafka/topics/regional_overrides/us/us_topics.jsonnet
RUNTIME ERROR: couldn't open import "../generated/_generated_raw_topic_data.json": import_callback did not return (string, bytes). Since 0.19.0 imports should be returned as bytes instead of as a string.  You may want to call .encode() on your string.
	/Users/nikharsaxena/workspace/ops/shared_config/kafka/topics/regional_overrides/us/../../lib/topic_builder.libsonnet:5:24-76	thunk <raw_topic_data>
	/Users/nikharsaxena/workspace/ops/shared_config/kafka/topics/regional_overrides/us/../../lib/topic_builder.libsonnet:12:19-33	thunk <o>
	std.jsonnet:1545:21	
	std.jsonnet:1545:5-33	function <anonymous>
	/Users/nikharsaxena/workspace/ops/shared_config/kafka/topics/regional_overrides/us/../../lib/topic_builder.libsonnet:12:5-46	function <get_raw_topic>
	/Users/nikharsaxena/workspace/ops/shared_config/kafka/topics/regional_overrides/us/../../lib/topic_builder.libsonnet:19:17-42	object <topics_to_deploy>
	/Users/nikharsaxena/workspace/ops/shared_config/kafka/topics/regional_overrides/us/../../lib/topic_builder.libsonnet:40:10-51	object <anonymous>
	/Users/nikharsaxena/workspace/ops/shared_config/kafka/topics/regional_overrides/us/../../lib/topic_builder.libsonnet:42:14-40	object <anonymous>
	/Users/nikharsaxena/workspace/ops/shared_config/kafka/topics/regional_overrides/us/../../lib/topic_builder.libsonnet:(52:60)-(58:4)	object <anonymous>
	During manifestation	

make: *** [materialize] Error 254
```

## After

Change the make target in ops repo in the integration pr
```
diff --git a/Makefile b/Makefile
index 36ca2334e..6bf32e3ff 100644
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ materialize-k8s:
 materialize:
 # Generates all the shared configuration and materializes the
 # results.
-       generate-raw-topic-data
+       generate-raw-topic-data --root-dir ./shared_config
        materialize-config -c -o _materialized_configs --root-dir ./shared_config/
        materialize-config -e '.terragrunt-cache' --root-dir ./terragrunt/
        materialize-config --root-dir ./k8s/clusters/
```

Install the locally developed version of sentry infra tools
```bash
 ~/w/ops  nikhars/fix/..-infra-tools !1 ?1  pip install /Users/nikharsaxena/workspace/sentry-infra-tools/dist/sentry_infra_tools-
 ok | direnv  .venv-sentry-kube py | 3.11.7  py  14:16:34
0.0.7-py3-none-any.whl
Processing /Users/nikharsaxena/workspace/sentry-infra-tools/dist/sentry_infra_tools-0.0.7-py3-none-any.whl
Requirement already satisfied: anyio==4.4.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (4.4.0)
Requirement already satisfied: attrs==24.2.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (24.2.0)
Requirement already satisfied: bcrypt==4.1.3 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (4.1.3)
Requirement already satisfied: cachetools==5.4.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (5.4.0)
Requirement already satisfied: certifi==2024.7.4 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2024.7.4)
Requirement already satisfied: cffi==1.16.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.16.0)
Requirement already satisfied: charset-normalizer==3.3.2 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (3.3.2)
Requirement already satisfied: click==8.1.7 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (8.1.7)
Requirement already satisfied: cryptography==42.0.8 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (42.0.8)
Requirement already satisfied: dictdiffer==0.9.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.9.0)
Requirement already satisfied: fastjsonschema==2.20.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.20.0)
Requirement already satisfied: google-api-core==2.19.1 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.19.1)
Requirement already satisfied: google-api-python-client==2.137.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.137.0)
Requirement already satisfied: google-auth==2.32.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.32.0)
Requirement already satisfied: google-auth-httplib2==0.2.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.2.0)
Requirement already satisfied: googleapis-common-protos==1.63.2 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.63.2)
Requirement already satisfied: h11==0.14.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.14.0)
Requirement already satisfied: httpcore==1.0.5 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.0.5)
Requirement already satisfied: httplib2==0.22.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.22.0)
Requirement already satisfied: httpx==0.27.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.27.0)
Requirement already satisfied: idna==3.7 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (3.7)
Requirement already satisfied: jinja2==3.1.4 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (3.1.4)
Requirement already satisfied: jsonnet==0.20.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.20.0)
Requirement already satisfied: jsonpatch==1.33 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.33)
Requirement already satisfied: jsonpath-ng==1.6.1 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.6.1)
Requirement already satisfied: jsonpointer==3.0.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (3.0.0)
Requirement already satisfied: jsonschema==4.23.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (4.23.0)
Requirement already satisfied: jsonschema-specifications==2023.12.1 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2023.12.1)
Requirement already satisfied: kubernetes==30.1.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (30.1.0)
Requirement already satisfied: lark==1.1.9 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.1.9)
Requirement already satisfied: markupsafe==2.1.5 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.1.5)
Requirement already satisfied: msgpack==1.0.8 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.0.8)
Requirement already satisfied: oauthlib==3.2.2 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (3.2.2)
Requirement already satisfied: paramiko==3.4.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (3.4.0)
Requirement already satisfied: pathspec==0.12.1 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.12.1)
Requirement already satisfied: ply==3.11 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (3.11)
Requirement already satisfied: proto-plus==1.24.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.24.0)
Requirement already satisfied: protobuf==5.27.2 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (5.27.2)
Requirement already satisfied: pyasn1==0.6.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.6.0)
Requirement already satisfied: pyasn1-modules==0.4.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.4.0)
Requirement already satisfied: pycparser==2.22 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.22)
Requirement already satisfied: pynacl==1.5.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.5.0)
Requirement already satisfied: pyparsing==3.1.2 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (3.1.2)
Requirement already satisfied: python-dateutil==2.9.0.post0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.9.0.post0)
Requirement already satisfied: python-hcl2==4.3.4 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (4.3.4)
Requirement already satisfied: python-rapidjson==1.8 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.8)
Requirement already satisfied: pyyaml==6.0.1 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (6.0.1)
Requirement already satisfied: referencing==0.35.1 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.35.1)
Requirement already satisfied: requests==2.32.3 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.32.3)
Requirement already satisfied: requests-oauthlib==2.0.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.0.0)
Requirement already satisfied: responses==0.25.3 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.25.3)
Requirement already satisfied: rpds-py==0.20.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.20.0)
Requirement already satisfied: rsa==4.9 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (4.9)
Requirement already satisfied: sentry-jsonish==0.0.2 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.0.2)
Requirement already satisfied: sentry-jsonnet==0.0.4 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.0.4)
Requirement already satisfied: sentry-kafka-schemas==0.1.103 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.1.103)
Requirement already satisfied: sentry-sdk==2.10.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.10.0)
Requirement already satisfied: six==1.16.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.16.0)
Requirement already satisfied: sniffio==1.3.1 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.3.1)
Requirement already satisfied: sshuttle==1.1.2 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.1.2)
Requirement already satisfied: tabulate==0.9.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.9.0)
Requirement already satisfied: types-jsonschema==4.23.0.20240813 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (4.23.0.20240813)
Requirement already satisfied: types-paramiko==3.4.0.20240423 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (3.4.0.20240423)
Requirement already satisfied: types-pyyaml==6.0.12.20240311 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (6.0.12.20240311)
Requirement already satisfied: types-requests==2.32.0.20240907 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.32.0.20240907)
Requirement already satisfied: types-setuptools==74.1.0.20240907 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (74.1.0.20240907)
Requirement already satisfied: types-tabulate==0.9.0.20240106 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (0.9.0.20240106)
Requirement already satisfied: typing-extensions==4.12.2 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (4.12.2)
Requirement already satisfied: uritemplate==4.1.1 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (4.1.1)
Requirement already satisfied: urllib3==2.2.2 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (2.2.2)
Requirement already satisfied: websocket-client==1.8.0 in ./.venv-sentry-kube/lib/python3.11/site-packages (from sentry-infra-tools==0.0.7) (1.8.0)
Installing collected packages: sentry-infra-tools
Successfully installed sentry-infra-tools-0.0.7

[notice] A new release of pip is available: 23.2.1 -> 24.2
[notice] To update, run: pip install --upgrade pip
```

Run the make command again
```bash
 ~/w/ops  nikhars/fix/..-infra-tools !1 ?1  make materialize
 ok | direnv  .venv-sentry-kube py | 3.11.7  py  14:16:38
generate-raw-topic-data --root-dir ./shared_config
Generating raw topic data
shared_config/kafka/topics/generated/_generated_raw_topic_data.json
materialize-config -c -o _materialized_configs --root-dir ./shared_config/
Validating yaml file schemas
Combining individual source files
Materializing jsonnet files
[GENERATED] shared_config/service_registry/combined/service_registry.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/us/us_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/ly/ly_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/geico/geico_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/goldmansachs/goldmansachs_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/de/de_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/disney/disney_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/consumer_groups/regional_overrides/s4s/s4s_consumer_groups.jsonnet
[GENERATED] shared_config/kafka/topics/regional_overrides/us/us_topics.jsonnet
[GENERATED] shared_config/kafka/topics/regional_overrides/ly/ly_topics.jsonnet
[GENERATED] shared_config/kafka/topics/regional_overrides/geico/geico_topics.jsonnet
[GENERATED] shared_config/kafka/topics/regional_overrides/goldmansachs/goldmansachs_topics.jsonnet
[GENERATED] shared_config/kafka/topics/regional_overrides/de/de_topics.jsonnet
[GENERATED] shared_config/kafka/topics/regional_overrides/disney/disney_topics.jsonnet
[GENERATED] shared_config/kafka/topics/regional_overrides/s4s/s4s_topics.jsonnet
materialize-config -e '.terragrunt-cache' --root-dir ./terragrunt/
Skipping individual files combination
Materializing jsonnet files
[GENERATED] terragrunt/regions/multi-tenant/datadog-shared-config/consumer-groups/us/monitors.jsonnet
[GENERATED] terragrunt/regions/multi-tenant/datadog-shared-config/consumer-groups/de/monitors.jsonnet
[GENERATED] terragrunt/regions/single-tenant/datadog-shared-config/consumer-groups/ly/monitors.jsonnet
[GENERATED] terragrunt/regions/single-tenant/datadog-shared-config/consumer-groups/geico/monitors.jsonnet
[GENERATED] terragrunt/regions/single-tenant/datadog-shared-config/consumer-groups/goldmansachs/monitors.jsonnet
[GENERATED] terragrunt/regions/single-tenant/datadog-shared-config/consumer-groups/disney/monitors.jsonnet
[GENERATED] terragrunt/regions/single-tenant/datadog-shared-config/consumer-groups/s4s/monitors.jsonnet
materialize-config --root-dir ./k8s/clusters/
Skipping individual files combination
Materializing jsonnet files
[GENERATED] k8s/clusters/us/_topicctl_generated.yaml.jsonnet
[GENERATED] k8s/clusters/ly/_topicctl_generated.yaml.jsonnet
[GENERATED] k8s/clusters/geico/_topicctl_generated.yaml.jsonnet
[GENERATED] k8s/clusters/goldmansachs/_topicctl_generated.yaml.jsonnet
[GENERATED] k8s/clusters/de/_topicctl_generated.yaml.jsonnet
[GENERATED] k8s/clusters/disney/_topicctl_generated.yaml.jsonnet
[GENERATED] k8s/clusters/s4s/_topicctl_generated.yaml.jsonnet
materialize-config -o ../generated_data --root-dir ./docs/_scripts
Skipping individual files combination
Materializing jsonnet files
[GENERATED] docs/_scripts/service_registry/services.jsonnet
```