### PR TITLE
chore(sync): Sync changes till a864cafd6a4771434bab51c79b7773877c8342d7

### DIFF
--- a/sentry_kube/cli/kafkactl.py
+++ b/sentry_kube/cli/kafkactl.py
@@ -47,7 +47,7 @@ def kafkactl(ctx):
         delete=False,
         only_delete=False,
         selective_delete=None,
-        root=True,
+        root=False,
         safe_to_evict=False,
         memory=None,
     )
@@ -68,7 +68,7 @@ def kafkactl(ctx):
         delete=False,
         only_delete=True,
         selective_delete=None,
-        root=True,
+        root=False,
         safe_to_evict=False,
         memory=None,
     )

--- a/sentry_kube/validate_services.py
+++ b/sentry_kube/validate_services.py
@@ -49,18 +49,21 @@ def test_services(filename: Sequence[str]) -> None:
                 Path(service_path) / "policy",
             ]
 
-            rendered = render_services(
+            rendered_lint = render_services(
                 resource.customer_name, resource.cluster_name, [resource.service_name]
             )
             click.echo(f"Linting resource {resource.service_name}")
             lint_errors_count += lint_and_print(
-                resource.customer_name, resource.cluster_name, resource.service_name, rendered
+                resource.customer_name, resource.cluster_name, resource.service_name, rendered_lint
             )
-
+            
+            rendered_validate = render_services(
+                resource.customer_name, resource.cluster_name, [resource.service_name]
+            )
             click.echo(f"Testing resource {resource.service_name}")
             for path in policies_paths:
                 if path.exists() and path.is_dir():
-                    for doc in rendered:
+                    for doc in rendered_validate:
                         click.echo(f"Evaluating policies in {path}")
                         cmd = ["conftest", "test", "--policy", path, "-"]
                         child_process = subprocess.Popen(


### PR DESCRIPTION
Sync between SHAs b65df3da50166daec95facef9ca44d8ebfed525b to a864cafd6a4771434bab51c79b7773877c8342d7

Diff
```bash
diff --git a/k8s/cli/sentry_kube/cli/kafkactl.py b/k8s/cli/sentry_kube/cli/kafkactl.py
index abd0d12e6..98baef2f1 100644
--- a/k8s/cli/sentry_kube/cli/kafkactl.py
+++ b/k8s/cli/sentry_kube/cli/kafkactl.py
@@ -47,7 +47,7 @@ def kafkactl(ctx):
         delete=False,
         only_delete=False,
         selective_delete=None,
-        root=True,
+        root=False,
         safe_to_evict=False,
         memory=None,
     )
@@ -68,7 +68,7 @@ def kafkactl(ctx):
         delete=False,
         only_delete=True,
         selective_delete=None,
-        root=True,
+        root=False,
         safe_to_evict=False,
         memory=None,
     )
diff --git a/k8s/cli/sentry_kube/validate_services.py b/k8s/cli/sentry_kube/validate_services.py
index b37f42afa..88431b028 100644
--- a/k8s/cli/sentry_kube/validate_services.py
+++ b/k8s/cli/sentry_kube/validate_services.py
@@ -49,18 +49,22 @@ def test_services(filename: Sequence[str]) -> None:
                 Path(service_path) / "policy",
             ]

-            rendered = render_services(
+            rendered_lint = render_services(
                 resource.customer_name, resource.cluster_name, [resource.service_name]
             )
             click.echo(f"Linting resource {resource.service_name}")
             lint_errors_count += lint_and_print(
-                resource.customer_name, resource.cluster_name, resource.service_name, rendered
+                resource.customer_name, resource.cluster_name, resource.service_name, rendered_lint
+            )
+
+            rendered_validate = render_services(
+                resource.customer_name, resource.cluster_name, [resource.service_name]
             )

             click.echo(f"Testing resource {resource.service_name}")
             for path in policies_paths:
                 if path.exists() and path.is_dir():
-                    for doc in rendered:
+                    for doc in rendered_validate:
                         click.echo(f"Evaluating policies in {path}")
                         cmd = ["conftest", "test", "--policy", path, "-"]
                         child_process = subprocess.Popen(
```