### PR TITLE
fix(service_registry): Dynamic detection of path

### DIFF
--- a/libsentrykube/tests/test_utils.py
+++ b/libsentrykube/tests/test_utils.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from libsentrykube.utils import get_service_registry_filepath, workspace_root
+
+
+@patch("importlib.import_module", return_value='/')
+@patch("importlib.resources.files", return_value=Path("a/b/c"))
+def test_get_service_registry_package_installed(
+    mock_import_module, 
+    mock_import_resources_path
+):
+    assert get_service_registry_filepath() == Path("a/b/c/sentry_service_registry/services.json")
+
+
+def test_get_service_registry_package_not_installed():
+    root = str(workspace_root())
+    assert get_service_registry_filepath() == Path(f"{root}/shared_config/_materialized_configs/service_registry/combined/service_registry.json")

--- a/libsentrykube/utils.py
+++ b/libsentrykube/utils.py
@@ -1,5 +1,6 @@
 import copy
 import hashlib
+import importlib
 import json
 import os
 import platform
@@ -391,12 +392,16 @@ def get_pubkey() -> Path:
 
 
 def get_service_registry_data(service_registry_id: str) -> dict:
-    filepath = (
-        workspace_root()
-        / "shared_config"
-        / "_materialized_configs"
-        / "service_registry"
-        / "combined"
-        / "service_registry.json"
-    )
+    filepath = get_service_registry_filepath()
     return json.loads(filepath.read_text())[service_registry_id]
+
+
+def get_service_registry_filepath() -> Path:
+    service_registry_pkg_name = "sentry_service_registry"
+    try:
+        importlib.import_module(service_registry_pkg_name)
+        path = str(importlib.resources.files(service_registry_pkg_name).joinpath(''))
+        return Path(path) / "sentry_service_registry" / "services.json"
+    except ImportError:
+        root = workspace_root()
+        return Path(f"{root}/shared_config/_materialized_configs/service_registry/combined/service_registry.json")

--- a/sentry_kube/validate_services.py
+++ b/sentry_kube/validate_services.py
@@ -49,18 +49,22 @@ def test_services(filename: Sequence[str]) -> None:
                 Path(service_path) / "policy",
             ]
 
-            rendered = render_services(
+            rendered_lint = render_services(
                 resource.customer_name, resource.cluster_name, [resource.service_name]
             )
             click.echo(f"Linting resource {resource.service_name}")
             lint_errors_count += lint_and_print(
-                resource.customer_name, resource.cluster_name, resource.service_name, rendered
+                resource.customer_name, resource.cluster_name, resource.service_name, rendered_lint
+            )
+
+            rendered_validate = render_services(
+                resource.customer_name, resource.cluster_name, [resource.service_name]
             )
 
             click.echo(f"Testing resource {resource.service_name}")
             for path in policies_paths:
                 if path.exists() and path.is_dir():
-                    for doc in rendered:
+                    for doc in rendered_validate:
                         click.echo(f"Evaluating policies in {path}")
                         cmd = ["conftest", "test", "--policy", path, "-"]
                         child_process = subprocess.Popen(

--- a/sentry_kube/validate_services.py
+++ b/sentry_kube/validate_services.py
@@ -49,22 +49,18 @@ def test_services(filename: Sequence[str]) -> None:
                 Path(service_path) / "policy",
             ]
 
-            rendered_lint = render_services(
+            rendered = render_services(
                 resource.customer_name, resource.cluster_name, [resource.service_name]
             )
             click.echo(f"Linting resource {resource.service_name}")
             lint_errors_count += lint_and_print(
-                resource.customer_name, resource.cluster_name, resource.service_name, rendered_lint
-            )
-
-            rendered_validate = render_services(
-                resource.customer_name, resource.cluster_name, [resource.service_name]
+                resource.customer_name, resource.cluster_name, resource.service_name, rendered
             )
 
             click.echo(f"Testing resource {resource.service_name}")
             for path in policies_paths:
                 if path.exists() and path.is_dir():
-                    for doc in rendered_validate:
+                    for doc in rendered:
                         click.echo(f"Evaluating policies in {path}")
                         cmd = ["conftest", "test", "--policy", path, "-"]
                         child_process = subprocess.Popen(


### PR DESCRIPTION
## Description
Since the service registry is moving to its own repository, we need a mechanism to get the relevant data from there. This PR introduces a mechanism which first checks whether the service registry package is installed or not. If yes, uses the file from the package. If not, falls back to hardcoded path from before.

## Local testing
Added this test code to see the path being resolved
```shell
def test_get_service_registry_package_installed():
    path = get_service_registry_filepath()
    print(path)
```

Output
Without the sentry-service-registry, notice the path
```shell
~/w/sentry-infra-tools/l/tests  nikhars/fix/service-registry +2 !2 ?2  pytest -vv test_utils.py::test_get_service_registry_package_installed -s
============================================== test session starts ===============================================
platform darwin -- Python 3.11.6, pytest-8.3.3, pluggy-1.5.0 -- /Users/nikharsaxena/workspace/sentry-infra-tools/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/nikharsaxena/workspace/sentry-infra-tools
configfile: pyproject.toml
plugins: anyio-4.4.0
collected 1 item

test_utils.py::test_get_service_registry_package_installed /Users/nikharsaxena/workspace/sentry-infra-tools/libsentrykube/tests/shared_config/_materialized_configs/service_registry/combined/service_registry.json
PASSED

=============================================== 1 passed in 0.02s ================================================
 ~/w/sentry-infra-tools/l/tests  nikhars/fix/service-registry +2 !2 ?2  pip show sentry-service-registry
WARNING: Package(s) not found: sentry-service-registry
```

With sentry-service-registry installed, notice the path printed at the end of the test
```shell
 ~/w/sentry-infra-tools/l/tests  nikhars/fix/service-registry +2 !2 ?2  pip install git+ssh://git@github.com/getsentry/service-registry.git@0.0.10
Collecting git+ssh://****@github.com/getsentry/service-registry.git@0.0.10
  Cloning ssh://****@github.com/getsentry/service-registry.git (to revision 0.0.10) to /private/var/folders/tb/g9_mm4k51rq0z28tykhkr66m0000gn/T/pip-req-build-2defvos1
  Running command git clone --filter=blob:none --quiet 'ssh://****@github.com/getsentry/service-registry.git' /private/var/folders/tb/g9_mm4k51rq0z28tykhkr66m0000gn/T/pip-req-build-2defvos1
  Running command git checkout -q c1cec4f193d167035c544c679e444f94836a6bf0
  Resolved ssh://****@github.com/getsentry/service-registry.git to commit c1cec4f193d167035c544c679e444f94836a6bf0
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: sentry-service-registry
  Building wheel for sentry-service-registry (pyproject.toml) ... done
  Created wheel for sentry-service-registry: filename=sentry_service_registry-0.0.10-py3-none-any.whl size=39005 sha256=287d40116aeb45ef1dd9093112d9ec7dfd6894ab138af1848f21d111464b498b
  Stored in directory: /private/var/folders/tb/g9_mm4k51rq0z28tykhkr66m0000gn/T/pip-ephem-wheel-cache-z717bjbd/wheels/cb/cc/5d/f07e02cab7ca2cfa2373ef52620c6ea7d4752793a1d3f7f6f1
Successfully built sentry-service-registry
Installing collected packages: sentry-service-registry
Successfully installed sentry-service-registry-0.0.10

[notice] A new release of pip available: 22.2.2 -> 24.2
[notice] To update, run: pip install --upgrade pip
 ~/w/sentry-infra-tools/l/tests  nikhars/fix/service-registry +2 !2 ?2  pytest -vv test_utils.py::test_get_service_registry_package_installed -s
============================================== test session starts ===============================================
platform darwin -- Python 3.11.6, pytest-8.3.3, pluggy-1.5.0 -- /Users/nikharsaxena/workspace/sentry-infra-tools/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/nikharsaxena/workspace/sentry-infra-tools
configfile: pyproject.toml
plugins: anyio-4.4.0
collected 1 item

test_utils.py::test_get_service_registry_package_installed /Users/nikharsaxena/workspace/sentry-infra-tools/.venv/lib/python3.11/site-packages/sentry_service_registry/sentry_service_registry/services.json
PASSED

=============================================== 1 passed in 0.01s ================================================
 ~/w/sentry-infra-tools/l/tests  nikhars/fix/service-registry +2 !2 ?2  pip show sentry-service-registry
 ok | direnv  3.11.6 py  10:48:17
Name: sentry-service-registry
Version: 0.0.10
Summary: Sentry Internal Service Registry
Home-page:
Author:
Author-email:
License:
Location: /Users/nikharsaxena/workspace/sentry-infra-tools/.venv/lib/python3.11/site-packages
Requires:
Required-by:
```