### PR TITLE
chore(readme): sentry-infra-tools in editable mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ $ sentry-kube --help
 * `SENTRY_KUBE_KUBECTL_VERSION`: Set `SENTRY_KUBE_KUBECTL_VERSION=1.22.17` to configure the kubectl version to use
 * `SENTRY_KUBE_NO_CONTEXT`: Set `SENTRY_KUBE_NO_CONTEXT=1` to skip checking for a functional kube context
 * `SENTRY_KUBE_ROOT`: Sets the workspace root. It defaults to the git root directory.
+
+## How to use sentry-infra-tools in editable mode (for development) in another environment
+
+Lets assume you have a local working copy of sentry-infra-tools in `~/sentry-infra-tools` and you want to use it in
+another virtual environment in editable mode. Here is how you can do it:
+
+1. Go to the environment where you want to use sentry-infra-tools in editable mode.
+2.

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@
 
 Follow the setup instructions in the [top-level README](../../README.md).
 
-
 ## Help
 
 All commands support `--help`, so please reference this.
 
 ```shell
-$ sentry-kube --help
+sentry-kube --help
 ```
 
 ## Environment Variables
@@ -41,8 +40,22 @@ $ sentry-kube --help
 
 ## How to use sentry-infra-tools in editable mode (for development) in another environment
 
-Lets assume you have a local working copy of sentry-infra-tools in `~/sentry-infra-tools` and you want to use it in
-another virtual environment in editable mode. Here is how you can do it:
+Lets assume you have a local working copy of sentry-infra-tools in
+`~/sentry-infra-tools`. Lets assume that you made some change
+in your local copy of sentry-infra-tools. But you would like to validate
+the change in a different virtual environment. Here is how you can do it:
 
-1. Go to the environment where you want to use sentry-infra-tools in editable mode.
-2.
+1. Remove the existing sentry-infra-tools package from the environment
+   where you want to test it out.
+
+```shell
+pip uninstall sentry-infra-tools
+```
+
+2. Install the local working copy of sentry-infra-tools in editable mode.
+
+```shell
+pip install -e ~/sentry-infra-tools
+```
+
+3. Done. You should now be able to use the local working copy of sentry-infra-tools in the other environment.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sentry-kube --help
 ## How to use sentry-infra-tools in editable mode (for development) in another environment
 
 Lets assume you have a local working copy of sentry-infra-tools in
-`~/sentry-infra-tools`. Lets assume that you made some change
+`<path-to-local-working-copy>/sentry-infra-tools`. Lets assume that you made some change
 in your local copy of sentry-infra-tools. But you would like to validate
 the change in a different virtual environment. Here is how you can do it:
 
@@ -52,10 +52,21 @@ the change in a different virtual environment. Here is how you can do it:
 pip uninstall sentry-infra-tools
 ```
 
-2. Install the local working copy of sentry-infra-tools in editable mode.
+2. Install the local working copy of sentry-infra-tools in editable mode. You can do this either manually as shown below.
 
 ```shell
-pip install -e ~/sentry-infra-tools
+pip install -e <path-to-local-working-copy>/sentry-infra-tools
 ```
+
+Or if `requirements.txt` is being used, you can remove the existing reference to `sentry-infra-tools` and add a reference to the local working copy.
+
+```shell
+# Edit python/requirements.txt
+# Remove any existing reference to sentry-infra-tools
+# Add the following reference to local working copy
+-e <path-to-local-working-copy>/sentry-infra-tools
+```
+
+and then run `pip install -r requirements.txt`.
 
 3. Done. You should now be able to use the local working copy of sentry-infra-tools in the other environment.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ referencing>=0.35.1
 Requests>=2.32.3
 sentry_jsonnet>=0.0.4
 sentry_sdk>=2.10.0
+setuptools>=69.0.3
 tabulate>=0.9.0


### PR DESCRIPTION
## Description
This PR adds contents to the README file with regards to how to install sentry-infra-tools in editable mode. Editable mode may be desired when developing software on sentry-kube but wanting to test in some other virtual environment.

## Testing
Created a new virtual environment. Installed the regular sentry-infra-tools package from pypi. Then removed the package from virtual environment and installed the local residing sentry-infra-tools package. Removed the `kube` output to see that `sentry-kube --help` indeed took the change into effect. The diff used for testing was
```shell
diff --git a/sentry_kube/cli/__init__.py b/sentry_kube/cli/__init__.py
index 531f7a3..34f154a 100644
--- a/sentry_kube/cli/__init__.py
+++ b/sentry_kube/cli/__init__.py
@@ -85,19 +85,6 @@ def _configure_colors(ctx):
 )
 @click.pass_context
 def main(ctx, *, cluster_name, root, customer, quiet, no_sentry):
-    """\b
- __                  __
-/  |                /  |
-$$ |   __  __    __ $$ |____    ______
-$$ |  /  |/  |  /  |$$      \\  /      \\
-$$ |_/$$/ $$ |  $$ |$$$$$$$  |/$$$$$$  |
-$$   $$<  $$ |  $$ |$$ |  $$ |$$    $$ |
-$$$$$$  \\ $$ \\__$$ |$$ |__$$ |$$$$$$$$/
-$$ | $$  |$$    $$/ $$    $$/ $$       |
-$$/   $$/  $$$$$$/  $$$$$$$/   $$$$$$$/
-
-Get kubed.
-"""
     if root is not None:
         set_workspace_root_start(root)
```
Logs of the tests are below
```shell
 ~/workspace  mkdir trials
 ~/workspace  pushd trials
~/workspace/trials ~/workspace ~ ~/workspace/sentry-infra-tools
 ~/workspace/trials  python3 -m venv virtualenv
 ~/workspace/trials  source virtualenv/bin/activate
 ~/workspace/trials  pip install sentry-infra-tools
Collecting sentry-infra-tools
  Downloading sentry_infra_tools-0.0.9-py3-none-any.whl.metadata (765 bytes)
Collecting click>=8.1.7 (from sentry-infra-tools)
  Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
Collecting dictdiffer>=0.9.0 (from sentry-infra-tools)
  Using cached dictdiffer-0.9.0-py2.py3-none-any.whl.metadata (4.8 kB)
Collecting google-api-python-client>=2.137.0 (from sentry-infra-tools)
  Downloading google_api_python_client-2.149.0-py2.py3-none-any.whl.metadata (6.7 kB)
Collecting httpx>=0.27.2 (from sentry-infra-tools)
  Using cached httpx-0.27.2-py3-none-any.whl.metadata (7.1 kB)
Collecting Jinja2>=3.1.4 (from sentry-infra-tools)
  Using cached jinja2-3.1.4-py3-none-any.whl.metadata (2.6 kB)
Collecting jsonpatch>=1.33 (from sentry-infra-tools)
  Using cached jsonpatch-1.33-py2.py3-none-any.whl.metadata (3.0 kB)
Collecting jsonpath-ng>=1.6.1 (from sentry-infra-tools)
  Downloading jsonpath-ng-1.7.0.tar.gz (37 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting jsonschema>=4.23.0 (from sentry-infra-tools)
  Using cached jsonschema-4.23.0-py3-none-any.whl.metadata (7.9 kB)
Collecting kubernetes>=30.1.0 (from sentry-infra-tools)
  Downloading kubernetes-31.0.0-py2.py3-none-any.whl.metadata (1.5 kB)
Collecting paramiko>=3.4.0 (from sentry-infra-tools)
  Downloading paramiko-3.5.0-py3-none-any.whl.metadata (4.4 kB)
Collecting protobuf>=5.28.1 (from sentry-infra-tools)
  Using cached protobuf-5.28.2-cp38-abi3-macosx_10_9_universal2.whl.metadata (592 bytes)
Collecting PyYAML>=6.0.1 (from sentry-infra-tools)
  Downloading PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl.metadata (2.1 kB)
Collecting referencing>=0.35.1 (from sentry-infra-tools)
  Using cached referencing-0.35.1-py3-none-any.whl.metadata (2.8 kB)
Collecting Requests>=2.32.3 (from sentry-infra-tools)
  Using cached requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
Collecting sentry-jsonnet>=0.0.4 (from sentry-infra-tools)
  Using cached sentry_jsonnet-0.0.4-py3-none-any.whl.metadata (320 bytes)
Collecting sentry-sdk>=2.10.0 (from sentry-infra-tools)
  Downloading sentry_sdk-2.16.0-py2.py3-none-any.whl.metadata (9.8 kB)
Collecting tabulate>=0.9.0 (from sentry-infra-tools)
  Using cached tabulate-0.9.0-py3-none-any.whl.metadata (34 kB)
Collecting httplib2<1.dev0,>=0.19.0 (from google-api-python-client>=2.137.0->sentry-infra-tools)
  Using cached httplib2-0.22.0-py3-none-any.whl.metadata (2.6 kB)
Collecting google-auth!=2.24.0,!=2.25.0,<3.0.0.dev0,>=1.32.0 (from google-api-python-client>=2.137.0->sentry-infra-tools)
  Downloading google_auth-2.35.0-py2.py3-none-any.whl.metadata (4.7 kB)
Collecting google-auth-httplib2<1.0.0,>=0.2.0 (from google-api-python-client>=2.137.0->sentry-infra-tools)
  Using cached google_auth_httplib2-0.2.0-py2.py3-none-any.whl.metadata (2.2 kB)
Collecting google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0.dev0,>=1.31.5 (from google-api-python-client>=2.137.0->sentry-infra-tools)
  Downloading google_api_core-2.21.0-py3-none-any.whl.metadata (2.8 kB)
Collecting uritemplate<5,>=3.0.1 (from google-api-python-client>=2.137.0->sentry-infra-tools)
  Using cached uritemplate-4.1.1-py2.py3-none-any.whl.metadata (2.9 kB)
Collecting anyio (from httpx>=0.27.2->sentry-infra-tools)
  Downloading anyio-4.6.2.post1-py3-none-any.whl.metadata (4.7 kB)
Collecting certifi (from httpx>=0.27.2->sentry-infra-tools)
  Using cached certifi-2024.8.30-py3-none-any.whl.metadata (2.2 kB)
Collecting httpcore==1.* (from httpx>=0.27.2->sentry-infra-tools)
  Downloading httpcore-1.0.6-py3-none-any.whl.metadata (21 kB)
Collecting idna (from httpx>=0.27.2->sentry-infra-tools)
  Downloading idna-3.10-py3-none-any.whl.metadata (10 kB)
Collecting sniffio (from httpx>=0.27.2->sentry-infra-tools)
  Using cached sniffio-1.3.1-py3-none-any.whl.metadata (3.9 kB)
Collecting h11<0.15,>=0.13 (from httpcore==1.*->httpx>=0.27.2->sentry-infra-tools)
  Using cached h11-0.14.0-py3-none-any.whl.metadata (8.2 kB)
Collecting MarkupSafe>=2.0 (from Jinja2>=3.1.4->sentry-infra-tools)
  Downloading MarkupSafe-3.0.1-cp312-cp312-macosx_11_0_arm64.whl.metadata (4.0 kB)
Collecting jsonpointer>=1.9 (from jsonpatch>=1.33->sentry-infra-tools)
  Using cached jsonpointer-3.0.0-py2.py3-none-any.whl.metadata (2.3 kB)
Collecting ply (from jsonpath-ng>=1.6.1->sentry-infra-tools)
  Using cached ply-3.11-py2.py3-none-any.whl.metadata (844 bytes)
Collecting attrs>=22.2.0 (from jsonschema>=4.23.0->sentry-infra-tools)
  Using cached attrs-24.2.0-py3-none-any.whl.metadata (11 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema>=4.23.0->sentry-infra-tools)
  Downloading jsonschema_specifications-2024.10.1-py3-none-any.whl.metadata (3.0 kB)
Collecting rpds-py>=0.7.1 (from jsonschema>=4.23.0->sentry-infra-tools)
  Using cached rpds_py-0.20.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (4.2 kB)
Collecting six>=1.9.0 (from kubernetes>=30.1.0->sentry-infra-tools)
  Using cached six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
Collecting python-dateutil>=2.5.3 (from kubernetes>=30.1.0->sentry-infra-tools)
  Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting websocket-client!=0.40.0,!=0.41.*,!=0.42.*,>=0.32.0 (from kubernetes>=30.1.0->sentry-infra-tools)
  Using cached websocket_client-1.8.0-py3-none-any.whl.metadata (8.0 kB)
Collecting requests-oauthlib (from kubernetes>=30.1.0->sentry-infra-tools)
  Using cached requests_oauthlib-2.0.0-py2.py3-none-any.whl.metadata (11 kB)
Collecting oauthlib>=3.2.2 (from kubernetes>=30.1.0->sentry-infra-tools)
  Using cached oauthlib-3.2.2-py3-none-any.whl.metadata (7.5 kB)
Collecting urllib3>=1.24.2 (from kubernetes>=30.1.0->sentry-infra-tools)
  Downloading urllib3-2.2.3-py3-none-any.whl.metadata (6.5 kB)
Collecting durationpy>=0.7 (from kubernetes>=30.1.0->sentry-infra-tools)
  Downloading durationpy-0.9-py3-none-any.whl.metadata (338 bytes)
Collecting bcrypt>=3.2 (from paramiko>=3.4.0->sentry-infra-tools)
  Downloading bcrypt-4.2.0-cp39-abi3-macosx_10_12_universal2.whl.metadata (9.6 kB)
Collecting cryptography>=3.3 (from paramiko>=3.4.0->sentry-infra-tools)
  Using cached cryptography-43.0.1-cp39-abi3-macosx_10_9_universal2.whl.metadata (5.4 kB)
Collecting pynacl>=1.5 (from paramiko>=3.4.0->sentry-infra-tools)
  Using cached PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl.metadata (8.7 kB)
Collecting charset-normalizer<4,>=2 (from Requests>=2.32.3->sentry-infra-tools)
  Downloading charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (34 kB)
Collecting jsonnet (from sentry-jsonnet>=0.0.4->sentry-infra-tools)
  Using cached jsonnet-0.20.0-cp312-cp312-macosx_14_0_arm64.whl
Collecting sentry-jsonish (from sentry-jsonnet>=0.0.4->sentry-infra-tools)
  Using cached sentry_jsonish-0.0.2-py3-none-any.whl.metadata (267 bytes)
Collecting cffi>=1.12 (from cryptography>=3.3->paramiko>=3.4.0->sentry-infra-tools)
  Downloading cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl.metadata (1.5 kB)
Collecting googleapis-common-protos<2.0.dev0,>=1.56.2 (from google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0.dev0,>=1.31.5->google-api-python-client>=2.137.0->sentry-infra-tools)
  Downloading googleapis_common_protos-1.65.0-py2.py3-none-any.whl.metadata (1.5 kB)
Collecting proto-plus<2.0.0dev,>=1.22.3 (from google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0.dev0,>=1.31.5->google-api-python-client>=2.137.0->sentry-infra-tools)
  Using cached proto_plus-1.24.0-py3-none-any.whl.metadata (2.2 kB)
Collecting cachetools<6.0,>=2.0.0 (from google-auth!=2.24.0,!=2.25.0,<3.0.0.dev0,>=1.32.0->google-api-python-client>=2.137.0->sentry-infra-tools)
  Downloading cachetools-5.5.0-py3-none-any.whl.metadata (5.3 kB)
Collecting pyasn1-modules>=0.2.1 (from google-auth!=2.24.0,!=2.25.0,<3.0.0.dev0,>=1.32.0->google-api-python-client>=2.137.0->sentry-infra-tools)
  Downloading pyasn1_modules-0.4.1-py3-none-any.whl.metadata (3.5 kB)
Collecting rsa<5,>=3.1.4 (from google-auth!=2.24.0,!=2.25.0,<3.0.0.dev0,>=1.32.0->google-api-python-client>=2.137.0->sentry-infra-tools)
  Using cached rsa-4.9-py3-none-any.whl.metadata (4.2 kB)
Collecting pyparsing!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,<4,>=2.4.2 (from httplib2<1.dev0,>=0.19.0->google-api-python-client>=2.137.0->sentry-infra-tools)
  Downloading pyparsing-3.2.0-py3-none-any.whl.metadata (5.0 kB)
Collecting pycparser (from cffi>=1.12->cryptography>=3.3->paramiko>=3.4.0->sentry-infra-tools)
  Using cached pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
Collecting pyasn1<0.7.0,>=0.4.6 (from pyasn1-modules>=0.2.1->google-auth!=2.24.0,!=2.25.0,<3.0.0.dev0,>=1.32.0->google-api-python-client>=2.137.0->sentry-infra-tools)
  Downloading pyasn1-0.6.1-py3-none-any.whl.metadata (8.4 kB)
Downloading sentry_infra_tools-0.0.9-py3-none-any.whl (122 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 122.8/122.8 kB 1.4 MB/s eta 0:00:00
Using cached click-8.1.7-py3-none-any.whl (97 kB)
Using cached dictdiffer-0.9.0-py2.py3-none-any.whl (16 kB)
Downloading google_api_python_client-2.149.0-py2.py3-none-any.whl (12.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12.3/12.3 MB 1.5 MB/s eta 0:00:00
Using cached httpx-0.27.2-py3-none-any.whl (76 kB)
Downloading httpcore-1.0.6-py3-none-any.whl (78 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 78.0/78.0 kB 1.6 MB/s eta 0:00:00
Using cached jinja2-3.1.4-py3-none-any.whl (133 kB)
Using cached jsonpatch-1.33-py2.py3-none-any.whl (12 kB)
Using cached jsonschema-4.23.0-py3-none-any.whl (88 kB)
Downloading kubernetes-31.0.0-py2.py3-none-any.whl (1.9 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.9/1.9 MB 1.6 MB/s eta 0:00:00
Downloading paramiko-3.5.0-py3-none-any.whl (227 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 227.1/227.1 kB 1.5 MB/s eta 0:00:00
Using cached protobuf-5.28.2-cp38-abi3-macosx_10_9_universal2.whl (414 kB)
Downloading PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl (173 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 173.3/173.3 kB 1.5 MB/s eta 0:00:00
Using cached referencing-0.35.1-py3-none-any.whl (26 kB)
Using cached requests-2.32.3-py3-none-any.whl (64 kB)
Using cached sentry_jsonnet-0.0.4-py3-none-any.whl (3.1 kB)
Downloading sentry_sdk-2.16.0-py2.py3-none-any.whl (313 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 313.8/313.8 kB 1.4 MB/s eta 0:00:00
Using cached tabulate-0.9.0-py3-none-any.whl (35 kB)
Using cached attrs-24.2.0-py3-none-any.whl (63 kB)
Downloading bcrypt-4.2.0-cp39-abi3-macosx_10_12_universal2.whl (472 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 472.4/472.4 kB 1.5 MB/s eta 0:00:00
Using cached certifi-2024.8.30-py3-none-any.whl (167 kB)
Downloading charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl (119 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 119.0/119.0 kB 1.3 MB/s eta 0:00:00
Using cached cryptography-43.0.1-cp39-abi3-macosx_10_9_universal2.whl (6.2 MB)
Downloading durationpy-0.9-py3-none-any.whl (3.5 kB)
Downloading google_api_core-2.21.0-py3-none-any.whl (156 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 156.4/156.4 kB 1.4 MB/s eta 0:00:00
Downloading google_auth-2.35.0-py2.py3-none-any.whl (208 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 209.0/209.0 kB 1.3 MB/s eta 0:00:00
Using cached google_auth_httplib2-0.2.0-py2.py3-none-any.whl (9.3 kB)
Using cached httplib2-0.22.0-py3-none-any.whl (96 kB)
Downloading idna-3.10-py3-none-any.whl (70 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 70.4/70.4 kB 1.3 MB/s eta 0:00:00
Using cached jsonpointer-3.0.0-py2.py3-none-any.whl (7.6 kB)
Downloading jsonschema_specifications-2024.10.1-py3-none-any.whl (18 kB)
Downloading MarkupSafe-3.0.1-cp312-cp312-macosx_11_0_arm64.whl (12 kB)
Using cached oauthlib-3.2.2-py3-none-any.whl (151 kB)
Using cached PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl (349 kB)
Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Using cached rpds_py-0.20.0-cp312-cp312-macosx_11_0_arm64.whl (313 kB)
Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Using cached uritemplate-4.1.1-py2.py3-none-any.whl (10 kB)
Downloading urllib3-2.2.3-py3-none-any.whl (126 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 126.3/126.3 kB 1.2 MB/s eta 0:00:00
Using cached websocket_client-1.8.0-py3-none-any.whl (58 kB)
Downloading anyio-4.6.2.post1-py3-none-any.whl (90 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 90.4/90.4 kB 1.4 MB/s eta 0:00:00
Using cached sniffio-1.3.1-py3-none-any.whl (10 kB)
Using cached ply-3.11-py2.py3-none-any.whl (49 kB)
Using cached requests_oauthlib-2.0.0-py2.py3-none-any.whl (24 kB)
Using cached sentry_jsonish-0.0.2-py3-none-any.whl (3.5 kB)
Downloading cachetools-5.5.0-py3-none-any.whl (9.5 kB)
Downloading cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl (178 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 178.8/178.8 kB 1.4 MB/s eta 0:00:00
Downloading googleapis_common_protos-1.65.0-py2.py3-none-any.whl (220 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 220.9/220.9 kB 1.4 MB/s eta 0:00:00
Using cached h11-0.14.0-py3-none-any.whl (58 kB)
Using cached proto_plus-1.24.0-py3-none-any.whl (50 kB)
Downloading pyasn1_modules-0.4.1-py3-none-any.whl (181 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 181.5/181.5 kB 1.4 MB/s eta 0:00:00
Downloading pyparsing-3.2.0-py3-none-any.whl (106 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 106.9/106.9 kB 1.3 MB/s eta 0:00:00
Using cached rsa-4.9-py3-none-any.whl (34 kB)
Downloading pyasn1-0.6.1-py3-none-any.whl (83 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 83.1/83.1 kB 1.5 MB/s eta 0:00:00
Using cached pycparser-2.22-py3-none-any.whl (117 kB)
Building wheels for collected packages: jsonpath-ng
  Building wheel for jsonpath-ng (pyproject.toml) ... done
  Created wheel for jsonpath-ng: filename=jsonpath_ng-1.7.0-py3-none-any.whl size=30100 sha256=581e0a7c03d8d0bbf1b27c3e8e26926c24ee5f86927dacdaf7fe39db6c1df8d4
  Stored in directory: /Users/nikharsaxena/Library/Caches/pip/wheels/7a/0c/fa/d549fbdb6b9a80b56efd0144b02a4adffeee1ba859fe4147e1
Successfully built jsonpath-ng
Installing collected packages: ply, jsonnet, durationpy, dictdiffer, websocket-client, urllib3, uritemplate, tabulate, sniffio, six, sentry-jsonish, rpds-py, PyYAML, pyparsing, pycparser, pyasn1, protobuf, oauthlib, MarkupSafe, jsonpointer, jsonpath-ng, idna, h11, click, charset-normalizer, certifi, cachetools, bcrypt, attrs, sentry-sdk, sentry-jsonnet, rsa, Requests, referencing, python-dateutil, pyasn1-modules, proto-plus, jsonpatch, Jinja2, httplib2, httpcore, googleapis-common-protos, cffi, anyio, requests-oauthlib, pynacl, jsonschema-specifications, httpx, google-auth, cryptography, paramiko, kubernetes, jsonschema, google-auth-httplib2, google-api-core, google-api-python-client, sentry-infra-tools
Successfully installed Jinja2-3.1.4 MarkupSafe-3.0.1 PyYAML-6.0.2 Requests-2.32.3 anyio-4.6.2.post1 attrs-24.2.0 bcrypt-4.2.0 cachetools-5.5.0 certifi-2024.8.30 cffi-1.17.1 charset-normalizer-3.4.0 click-8.1.7 cryptography-43.0.1 dictdiffer-0.9.0 durationpy-0.9 google-api-core-2.21.0 google-api-python-client-2.149.0 google-auth-2.35.0 google-auth-httplib2-0.2.0 googleapis-common-protos-1.65.0 h11-0.14.0 httpcore-1.0.6 httplib2-0.22.0 httpx-0.27.2 idna-3.10 jsonnet-0.20.0 jsonpatch-1.33 jsonpath-ng-1.7.0 jsonpointer-3.0.0 jsonschema-4.23.0 jsonschema-specifications-2024.10.1 kubernetes-31.0.0 oauthlib-3.2.2 paramiko-3.5.0 ply-3.11 proto-plus-1.24.0 protobuf-5.28.2 pyasn1-0.6.1 pyasn1-modules-0.4.1 pycparser-2.22 pynacl-1.5.0 pyparsing-3.2.0 python-dateutil-2.9.0.post0 referencing-0.35.1 requests-oauthlib-2.0.0 rpds-py-0.20.0 rsa-4.9 sentry-infra-tools-0.0.9 sentry-jsonish-0.0.2 sentry-jsonnet-0.0.4 sentry-sdk-2.16.0 six-1.16.0 sniffio-1.3.1 tabulate-0.9.0 uritemplate-4.1.1 urllib3-2.2.3 websocket-client-1.8.0

[notice] A new release of pip is available: 24.0 -> 24.2
[notice] To update, run: pip install --upgrade pip
 ~/workspace/trials  sentry-kube --help
Traceback (most recent call last):
  File "/Users/nikharsaxena/workspace/trials/virtualenv/bin/sentry-kube", line 5, in <module>
    from sentry_kube.cli import main
  File "/Users/nikharsaxena/workspace/trials/virtualenv/lib/python3.12/site-packages/sentry_kube/cli/__init__.py", line 222, in <module>
    module = import_module(module_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nikharsaxena/workspace/trials/virtualenv/lib/python3.12/site-packages/sentry_kube/cli/apply.py", line 20, in <module>
    from libsentrykube.kube import materialize, render_templates
  File "/Users/nikharsaxena/workspace/trials/virtualenv/lib/python3.12/site-packages/libsentrykube/kube.py", line 15, in <module>
    from libsentrykube.loader import load_macros
  File "/Users/nikharsaxena/workspace/trials/virtualenv/lib/python3.12/site-packages/libsentrykube/loader.py", line 2, in <module>
    from pkg_resources import iter_entry_points
ModuleNotFoundError: No module named 'pkg_resources'
Sentry is attempting to send 2 pending events
Waiting up to 2 seconds
Press Ctrl-C to quit
 ~/workspace/trials  pip install setuptools
Collecting setuptools
  Using cached setuptools-75.2.0-py3-none-any.whl.metadata (6.9 kB)
Using cached setuptools-75.2.0-py3-none-any.whl (1.2 MB)
Installing collected packages: setuptools
Successfully installed setuptools-75.2.0

[notice] A new release of pip is available: 24.0 -> 24.2
[notice] To update, run: pip install --upgrade pip
 ~/workspace/trials  sentry-kube --help
Usage: sentry-kube [OPTIONS] COMMAND [ARGS]...

   __                  __
  /  |                /  |
  $$ |   __  __    __ $$ |____    ______
  $$ |  /  |/  |  /  |$$      \  /      \
  $$ |_/$$/ $$ |  $$ |$$$$$$$  |/$$$$$$  |
  $$   $$<  $$ |  $$ |$$ |  $$ |$$    $$ |
  $$$$$$  \ $$ \__$$ |$$ |__$$ |$$$$$$$$/
  $$ | $$  |$$    $$/ $$    $$/ $$       |
  $$/   $$/  $$$$$$/  $$$$$$$/   $$$$$$$/

  Get kubed.

Options:
  -c, --cluster TEXT   Cluster name to operate on. This is ignored if the
                       customer has one cluster
  --root DIRECTORY     Skip auto-detection of root directory.
  -C, --customer TEXT  Customer name. Does not override the customer for
                       `connect`.
  -q, --quiet          Do not output informational messages
  -s, --no-sentry      Disables sending errors/transactions to Sentry when
                       running
  --help               Show this message and exit.

Commands:
  apply
  audit                   Generates a list of objects that exist...
  cluster
  connect
  datadog-log             Submits events to DataDog.
  datadog-log-terragrunt  Submits terraform events to DataDog.
  detect-drift            This command runs a `sentry-kube diff` on all...
  diff                    Render a diff between production and local...
  edit-secret             kubectl edit secret, but made convenient.
  get-context             Get the kubernetes context value for use in...
  get-customers           Gets the list of all avaliable customers.
  k9s                     Start k9s (a terminal based Kubernetes UI)
  kafkactl                Spawn kafkactl environment pod.
  kubectl                 Confirmation wrapper for kubectl, for when you...
  render                  Render a service(s).
  rendervalues            Render the end state of variables (after...
  resolve-pvc             Figure out which Pod and Node a PVC is bound to.
  restart                 Restarts deployment(s) by bumping the...
  run-job                 Apply a service's job to production.
  run-pod
  scale
  scp                     Use SCP to transfer a file.
  ssh                     SSH into a host.
  toolbox                 Run a toolbox pod.
  tunnel                  IAP tunnel into a host.
  validate                Renders the specified service and then runs...
 ~/workspace/trials  pip uninstall sentry-infra-tools
Found existing installation: sentry-infra-tools 0.0.9
Uninstalling sentry-infra-tools-0.0.9:
  Would remove:
    /Users/nikharsaxena/workspace/trials/virtualenv/bin/materialize-config
    /Users/nikharsaxena/workspace/trials/virtualenv/bin/pr-approver
    /Users/nikharsaxena/workspace/trials/virtualenv/bin/pr-docs
    /Users/nikharsaxena/workspace/trials/virtualenv/bin/sentry-kube
    /Users/nikharsaxena/workspace/trials/virtualenv/bin/sentry-kube-pop
    /Users/nikharsaxena/workspace/trials/virtualenv/lib/python3.12/site-packages/assistant/*
    /Users/nikharsaxena/workspace/trials/virtualenv/lib/python3.12/site-packages/config_builder/*
    /Users/nikharsaxena/workspace/trials/virtualenv/lib/python3.12/site-packages/libsentrykube/*
    /Users/nikharsaxena/workspace/trials/virtualenv/lib/python3.12/site-packages/pr_approver/*
    /Users/nikharsaxena/workspace/trials/virtualenv/lib/python3.12/site-packages/sentry_infra_tools-0.0.9.dist-info/*
    /Users/nikharsaxena/workspace/trials/virtualenv/lib/python3.12/site-packages/sentry_kube/*
Proceed (Y/n)? Y
  Successfully uninstalled sentry-infra-tools-0.0.9
 ~/workspace/trials  pip install -e ~/workspace/sentry-infra-tools/
Obtaining file:///Users/nikharsaxena/workspace/sentry-infra-tools
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: click>=8.1.7 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (8.1.7)
Requirement already satisfied: dictdiffer>=0.9.0 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (0.9.0)
Requirement already satisfied: google-api-python-client>=2.137.0 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (2.149.0)
Requirement already satisfied: httpx>=0.27.2 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (0.27.2)
Requirement already satisfied: Jinja2>=3.1.4 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (3.1.4)
Requirement already satisfied: jsonpatch>=1.33 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (1.33)
Requirement already satisfied: jsonpath-ng>=1.6.1 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (1.7.0)
Requirement already satisfied: jsonschema>=4.23.0 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (4.23.0)
Requirement already satisfied: kubernetes>=30.1.0 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (31.0.0)
Requirement already satisfied: paramiko>=3.4.0 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (3.5.0)
Requirement already satisfied: protobuf>=5.28.1 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (5.28.2)
Requirement already satisfied: PyYAML>=6.0.1 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (6.0.2)
Requirement already satisfied: referencing>=0.35.1 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (0.35.1)
Requirement already satisfied: Requests>=2.32.3 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (2.32.3)
Requirement already satisfied: sentry-jsonnet>=0.0.4 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (0.0.4)
Requirement already satisfied: sentry-sdk>=2.10.0 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (2.16.0)
Requirement already satisfied: setuptools>=69.0.3 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (75.2.0)
Requirement already satisfied: tabulate>=0.9.0 in ./virtualenv/lib/python3.12/site-packages (from sentry-infra-tools==0.0.9) (0.9.0)
Requirement already satisfied: httplib2<1.dev0,>=0.19.0 in ./virtualenv/lib/python3.12/site-packages (from google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (0.22.0)
Requirement already satisfied: google-auth!=2.24.0,!=2.25.0,<3.0.0.dev0,>=1.32.0 in ./virtualenv/lib/python3.12/site-packages (from google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (2.35.0)
Requirement already satisfied: google-auth-httplib2<1.0.0,>=0.2.0 in ./virtualenv/lib/python3.12/site-packages (from google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (0.2.0)
Requirement already satisfied: google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0.dev0,>=1.31.5 in ./virtualenv/lib/python3.12/site-packages (from google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (2.21.0)
Requirement already satisfied: uritemplate<5,>=3.0.1 in ./virtualenv/lib/python3.12/site-packages (from google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (4.1.1)
Requirement already satisfied: anyio in ./virtualenv/lib/python3.12/site-packages (from httpx>=0.27.2->sentry-infra-tools==0.0.9) (4.6.2.post1)
Requirement already satisfied: certifi in ./virtualenv/lib/python3.12/site-packages (from httpx>=0.27.2->sentry-infra-tools==0.0.9) (2024.8.30)
Requirement already satisfied: httpcore==1.* in ./virtualenv/lib/python3.12/site-packages (from httpx>=0.27.2->sentry-infra-tools==0.0.9) (1.0.6)
Requirement already satisfied: idna in ./virtualenv/lib/python3.12/site-packages (from httpx>=0.27.2->sentry-infra-tools==0.0.9) (3.10)
Requirement already satisfied: sniffio in ./virtualenv/lib/python3.12/site-packages (from httpx>=0.27.2->sentry-infra-tools==0.0.9) (1.3.1)
Requirement already satisfied: h11<0.15,>=0.13 in ./virtualenv/lib/python3.12/site-packages (from httpcore==1.*->httpx>=0.27.2->sentry-infra-tools==0.0.9) (0.14.0)
Requirement already satisfied: MarkupSafe>=2.0 in ./virtualenv/lib/python3.12/site-packages (from Jinja2>=3.1.4->sentry-infra-tools==0.0.9) (3.0.1)
Requirement already satisfied: jsonpointer>=1.9 in ./virtualenv/lib/python3.12/site-packages (from jsonpatch>=1.33->sentry-infra-tools==0.0.9) (3.0.0)
Requirement already satisfied: ply in ./virtualenv/lib/python3.12/site-packages (from jsonpath-ng>=1.6.1->sentry-infra-tools==0.0.9) (3.11)
Requirement already satisfied: attrs>=22.2.0 in ./virtualenv/lib/python3.12/site-packages (from jsonschema>=4.23.0->sentry-infra-tools==0.0.9) (24.2.0)
Requirement already satisfied: jsonschema-specifications>=2023.03.6 in ./virtualenv/lib/python3.12/site-packages (from jsonschema>=4.23.0->sentry-infra-tools==0.0.9) (2024.10.1)
Requirement already satisfied: rpds-py>=0.7.1 in ./virtualenv/lib/python3.12/site-packages (from jsonschema>=4.23.0->sentry-infra-tools==0.0.9) (0.20.0)
Requirement already satisfied: six>=1.9.0 in ./virtualenv/lib/python3.12/site-packages (from kubernetes>=30.1.0->sentry-infra-tools==0.0.9) (1.16.0)
Requirement already satisfied: python-dateutil>=2.5.3 in ./virtualenv/lib/python3.12/site-packages (from kubernetes>=30.1.0->sentry-infra-tools==0.0.9) (2.9.0.post0)
Requirement already satisfied: websocket-client!=0.40.0,!=0.41.*,!=0.42.*,>=0.32.0 in ./virtualenv/lib/python3.12/site-packages (from kubernetes>=30.1.0->sentry-infra-tools==0.0.9) (1.8.0)
Requirement already satisfied: requests-oauthlib in ./virtualenv/lib/python3.12/site-packages (from kubernetes>=30.1.0->sentry-infra-tools==0.0.9) (2.0.0)
Requirement already satisfied: oauthlib>=3.2.2 in ./virtualenv/lib/python3.12/site-packages (from kubernetes>=30.1.0->sentry-infra-tools==0.0.9) (3.2.2)
Requirement already satisfied: urllib3>=1.24.2 in ./virtualenv/lib/python3.12/site-packages (from kubernetes>=30.1.0->sentry-infra-tools==0.0.9) (2.2.3)
Requirement already satisfied: durationpy>=0.7 in ./virtualenv/lib/python3.12/site-packages (from kubernetes>=30.1.0->sentry-infra-tools==0.0.9) (0.9)
Requirement already satisfied: bcrypt>=3.2 in ./virtualenv/lib/python3.12/site-packages (from paramiko>=3.4.0->sentry-infra-tools==0.0.9) (4.2.0)
Requirement already satisfied: cryptography>=3.3 in ./virtualenv/lib/python3.12/site-packages (from paramiko>=3.4.0->sentry-infra-tools==0.0.9) (43.0.1)
Requirement already satisfied: pynacl>=1.5 in ./virtualenv/lib/python3.12/site-packages (from paramiko>=3.4.0->sentry-infra-tools==0.0.9) (1.5.0)
Requirement already satisfied: charset-normalizer<4,>=2 in ./virtualenv/lib/python3.12/site-packages (from Requests>=2.32.3->sentry-infra-tools==0.0.9) (3.4.0)
Requirement already satisfied: jsonnet in ./virtualenv/lib/python3.12/site-packages (from sentry-jsonnet>=0.0.4->sentry-infra-tools==0.0.9) (0.20.0)
Requirement already satisfied: sentry-jsonish in ./virtualenv/lib/python3.12/site-packages (from sentry-jsonnet>=0.0.4->sentry-infra-tools==0.0.9) (0.0.2)
Requirement already satisfied: cffi>=1.12 in ./virtualenv/lib/python3.12/site-packages (from cryptography>=3.3->paramiko>=3.4.0->sentry-infra-tools==0.0.9) (1.17.1)
Requirement already satisfied: googleapis-common-protos<2.0.dev0,>=1.56.2 in ./virtualenv/lib/python3.12/site-packages (from google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0.dev0,>=1.31.5->google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (1.65.0)
Requirement already satisfied: proto-plus<2.0.0dev,>=1.22.3 in ./virtualenv/lib/python3.12/site-packages (from google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0.dev0,>=1.31.5->google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (1.24.0)
Requirement already satisfied: cachetools<6.0,>=2.0.0 in ./virtualenv/lib/python3.12/site-packages (from google-auth!=2.24.0,!=2.25.0,<3.0.0.dev0,>=1.32.0->google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (5.5.0)
Requirement already satisfied: pyasn1-modules>=0.2.1 in ./virtualenv/lib/python3.12/site-packages (from google-auth!=2.24.0,!=2.25.0,<3.0.0.dev0,>=1.32.0->google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (0.4.1)
Requirement already satisfied: rsa<5,>=3.1.4 in ./virtualenv/lib/python3.12/site-packages (from google-auth!=2.24.0,!=2.25.0,<3.0.0.dev0,>=1.32.0->google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (4.9)
Requirement already satisfied: pyparsing!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,<4,>=2.4.2 in ./virtualenv/lib/python3.12/site-packages (from httplib2<1.dev0,>=0.19.0->google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (3.2.0)
Requirement already satisfied: pycparser in ./virtualenv/lib/python3.12/site-packages (from cffi>=1.12->cryptography>=3.3->paramiko>=3.4.0->sentry-infra-tools==0.0.9) (2.22)
Requirement already satisfied: pyasn1<0.7.0,>=0.4.6 in ./virtualenv/lib/python3.12/site-packages (from pyasn1-modules>=0.2.1->google-auth!=2.24.0,!=2.25.0,<3.0.0.dev0,>=1.32.0->google-api-python-client>=2.137.0->sentry-infra-tools==0.0.9) (0.6.1)
Building wheels for collected packages: sentry-infra-tools
  Building editable for sentry-infra-tools (pyproject.toml) ... done
  Created wheel for sentry-infra-tools: filename=sentry_infra_tools-0.0.9-0.editable-py3-none-any.whl size=5043 sha256=9ba30ec5957365ed33721180dd5aeaf5194df2a501da18c325959c3e984e5b25
  Stored in directory: /private/var/folders/tb/g9_mm4k51rq0z28tykhkr66m0000gn/T/pip-ephem-wheel-cache-zz65qml_/wheels/8f/e9/9f/e7ad5cc479d36bfc3762e052bfef74181cc5e86851b5cb0733
Successfully built sentry-infra-tools
Installing collected packages: sentry-infra-tools
Successfully installed sentry-infra-tools-0.0.9

[notice] A new release of pip is available: 24.0 -> 24.2
[notice] To update, run: pip install --upgrade pip
 ~/workspace/trials  sentry-kube --help
Usage: sentry-kube [OPTIONS] COMMAND [ARGS]...

Options:
  -c, --cluster TEXT   Cluster name to operate on. This is ignored if the
                       customer has one cluster
  --root DIRECTORY     Skip auto-detection of root directory.
  -C, --customer TEXT  Customer name. Does not override the customer for
                       `connect`.
  -q, --quiet          Do not output informational messages
  -s, --no-sentry      Disables sending errors/transactions to Sentry when
                       running
  --help               Show this message and exit.

Commands:
  apply
  audit                   Generates a list of objects that exist...
  cluster
  connect
  datadog-log             Submits events to DataDog.
  datadog-log-terragrunt  Submits terraform events to DataDog.
  detect-drift            This command runs a `sentry-kube diff` on all...
  diff                    Render a diff between production and local...
  edit-secret             kubectl edit secret, but made convenient.
  get-context             Get the kubernetes context value for use in...
  get-customers           Gets the list of all avaliable customers.
  k9s                     Start k9s (a terminal based Kubernetes UI)
  kafkactl                Spawn kafkactl environment pod.
  kubectl                 Confirmation wrapper for kubectl, for when you...
  render                  Render a service(s).
  rendervalues            Render the end state of variables (after...
  resolve-pvc             Figure out which Pod and Node a PVC is bound to.
  restart                 Restarts deployment(s) by bumping the...
  run-job                 Apply a service's job to production.
  run-pod
  scale
  scp                     Use SCP to transfer a file.
  ssh                     SSH into a host.
  toolbox                 Run a toolbox pod.
  tunnel                  IAP tunnel into a host.
  validate                Renders the specified service and then runs...

```