### PR TITLE
Sync till 134da6c507d2ee342575762cb3e47cc25b898767

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 click>=8.1.7
 dictdiffer>=0.9.0
 google_api_python_client>=2.137.0
-google-cloud-secret-manager>=2.15.0
+google-cloud-secret-manager>=2.20.2
 httpx>=0.27.2
 Jinja2>=3.1.4
 jsonpatch>=1.33

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 click>=8.1.7
 dictdiffer>=0.9.0
 google_api_python_client>=2.137.0
+google-cloud-secret-manager>=2.15.0
 httpx>=0.27.2
 Jinja2>=3.1.4
 jsonpatch>=1.33

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 click>=8.1.7
 dictdiffer>=0.9.0
 google_api_python_client>=2.137.0
-google-cloud-secret-manager>=2.20.2
+google-cloud-secret-manager>=2.15.0
 httpx>=0.27.2
 Jinja2>=3.1.4
 jsonpatch>=1.33

--- a/sentry_kube/cli/pg/__init__.py
+++ b/sentry_kube/cli/pg/__init__.py
@@ -1,0 +1,14 @@
+import click
+
+from . import create_user
+
+
+__all__ = ("pg",)
+
+
+@click.group()
+def pg():
+    pass
+
+
+pg.command(help=create_user.cmd_help)(create_user.create_user)

--- a/sentry_kube/cli/pg/create_user.py
+++ b/sentry_kube/cli/pg/create_user.py
@@ -1,0 +1,317 @@
+import hmac
+import json
+from base64 import standard_b64decode, standard_b64encode
+from hashlib import pbkdf2_hmac, sha256
+from os import urandom
+from secrets import token_urlsafe
+
+import click
+from google.api_core import exceptions
+from google.cloud import secretmanager
+from kubernetes.client import CoreV1Api
+from kubernetes.client.rest import ApiException
+
+from libsentrykube.utils import kube_get_client
+
+# run this script only once per region.
+# this script generates and uploads the necessary username and passwords for postgres pgbouncer users.
+
+salt_size = 16
+digest_len = 32
+iterations = 4096
+
+
+cmd_help = """
+
+This command simplifies creation of users and corresponding userlist entries in the following
+places:
+
+- plaintext passwords in k8s secret `sentry-db-password`, to be used by the `getsentry` deployment,
+  `sentry` container;
+
+- userlist in k8s secret `service-pgbouncer`, to be used by intermediary and sidecar `pgbouncer`
+  containers;
+
+- userlist in GCP Secret Manager secret `postgres`, to be used by Salt on `db-*` instances.
+
+The script is addition-only. This is a safety net to avoid accidental user removal.
+
+
+## Step 1
+
+The first step generates plaintext passwords. You can specify several `--username` parameters if you
+want:
+
+\b
+```
+sentry-kube -C {env} pg create-user --generate-plaintext --username alice --username bob
+```
+
+The resulting password will be saved to `sentry-db-password` k8s secret (or you can override it with
+the `--plaintext-k8s-secret` option) as a separate secret entry:
+
+\b
+```
+apiVersion: v1
+data:
+  alice: YWFh
+  bob: YmJi
+kind: Secret
+```
+
+## Step 2
+
+After plaintext secrets populated, it is possible to generate userlist entries out of them. There is
+no need to specify usernames, as they will be taken from the plaintext k8s secret.
+
+\b
+```
+sentry-kube -C {env} pg create-user --generate-userlist
+```
+
+This will update userlists both in k8s secrets and Secret Manager.
+
+
+## Maintenance
+
+> [!WARNING]
+> Proceed with caution. This may start an incident if used carelessly.
+
+If you really want to delete users, you can do so with standard commands:
+
+\b
+```
+sentry-kube -q -C s4s kubectl edit secrets sentry-db-password
+sentry-kube -q -C s4s edit-secret sentry-db-password
+sentry-kube -q -C s4s edit-secret service-pgbouncer
+```
+
+"""
+
+
+
+def b64enc(b: bytes) -> str:
+    return standard_b64encode(b).decode("utf-8")
+
+
+def pg_scram_sha256(passwd: str) -> str:
+    salt = urandom(salt_size)
+    digest_key = pbkdf2_hmac("sha256", passwd.encode("utf8"), salt, iterations, digest_len)
+    client_key = hmac.digest(digest_key, "Client Key".encode("UTF-8"), "sha256")
+    stored_key = sha256(client_key).digest()
+    server_key = hmac.digest(digest_key, "Server Key".encode("UTF-8"), "sha256")
+    return (
+        f"SCRAM-SHA-256${iterations}:{b64enc(salt)}" f"${b64enc(stored_key)}:{b64enc(server_key)}"
+    )
+
+
+def decode_userlist(userlist: str):
+    # userlist is a base64 encoded list of users and their passwords.
+    # the format is as follows:
+    # "user1" "SCRAM-SHA-256...."
+    # "user2" "SCRAM-SHA-256...."
+    hashes = {}
+    for line in userlist.rstrip("\n").split("\n"):
+        (username, password_string) = line.split(" ")
+        username = username.replace('"', "")
+        password_string = password_string.replace('"', "")
+        hashes[username] = password_string
+    return hashes
+
+
+def upload_plaintext_to_k8s_secret(
+    api: CoreV1Api,
+    users: dict[str, dict[str, str]],
+    secret_name: str
+) -> None:
+    # TODO: create if not exists
+    # api.create_namespaced_secret(namespace, body)
+
+    secret = api.read_namespaced_secret(namespace="default", name=secret_name)
+    print(f"### Kubernetes secret `default/{secret_name}`, BEFORE")
+    for secret_item in secret.data:
+        print(f"{secret_item}: {secret.data[secret_item]}")
+    print()
+
+    is_modified = False
+    for user in users:
+        if user not in secret.data:
+            secret.data[user] = b64enc(users[user]["password"].encode("utf-8"))
+            is_modified = True
+
+    if not is_modified:
+        print(f"Kubernetes secret `default/{secret_name}` is up to date. No new users.")
+        return
+    print(f"### Kubernetes secret `default/{secret_name}`, AFTER")
+    for secret_item in secret.data:
+        print(f"{secret_item}: {secret.data[secret_item]}")
+    print()
+
+    confirm = input("Type 'yes' to apply: ")
+    if confirm != "yes":
+        print("WARNING: This change was not applied.")
+        return
+
+    api.patch_namespaced_secret(namespace="default", name=secret_name, body={"data": secret.data})
+
+
+def merge_userlists(encoded_userlist: str, users: dict[str, dict[str, str]], label: str):
+    userlist = standard_b64decode(encoded_userlist).decode("utf-8")
+
+    print(f"### {label}, BEFORE")
+    print(userlist)
+    print()
+
+    hashes = decode_userlist(userlist)
+
+    is_modified = False
+    for user in users:
+        if user not in hashes:
+            hashes[user] = users[user]["scram"]
+            is_modified = True
+
+    if not is_modified:
+        print(f"{label} is up to date. No new users.\n")
+        return
+
+    userlist = ""
+    for entry in hashes:
+        userlist += f'"{entry}" "{hashes[entry]}"\n'
+
+    print(f"### {label}, AFTER")
+    print(userlist)
+    print()
+
+    confirm = input("Type 'yes' to apply: ")
+    if confirm != "yes":
+        print("WARNING: This change was not applied.")
+        return
+
+    encoded_userlist = standard_b64encode(userlist.encode("utf-8")).decode("utf-8")
+    return encoded_userlist
+
+
+def upload_userlist_to_k8s_secret(
+    api: CoreV1Api,
+    users: dict[str,
+    dict[str, str]],
+    secret_name: str
+) -> None:
+    # TODO: create if not exists
+    # api.create_namespaced_secret(namespace, body)
+
+    secret = api.read_namespaced_secret(namespace="default", name=secret_name)
+    encoded_userlist = secret.data["userlist"]
+    merged_userlist = merge_userlists(
+        encoded_userlist, users, f"Kubernetes secret `default/{secret_name}`"
+    )
+    if merged_userlist:
+        api.patch_namespaced_secret(
+            namespace="default",
+            name=secret_name,
+            body={"data": {"userlist": merged_userlist}},
+        )
+
+
+def upload_userlist_to_google_secret(
+    project_id: str,
+    users: dict[str, dict[str, str]],
+    secret_id: str
+) -> None:
+    # run gcloud auth application-default login for the gcloud python lib
+
+    # Create the Secret Manager client.
+    client = secretmanager.SecretManagerServiceClient()
+
+    data = {"userlist": ""}
+
+    # get the current secret to ensure we're not double adding
+    version_id = "latest"
+    name = f"projects/{project_id}/secrets/{secret_id}/versions/{version_id}"
+    try:
+        response = client.access_secret_version(request={"name": name})
+        payload = response.payload.data.decode("utf-8")
+        data = json.loads(payload)
+    except exceptions.NotFound:
+        print(
+            f"ERROR: The secret `{secret_id}` should be created with Terragrunt before running this script."
+        )
+        return
+
+    # decode the userlist
+    encoded_userlist = data["userlist"]
+    merged_userlist = merge_userlists(
+        encoded_userlist, users, f"Secret Manager secret `{secret_id}`"
+    )
+    if merged_userlist:
+        data["userlist"] = merged_userlist
+        secret_data = json.dumps(data).encode("utf-8")
+        parent = client.secret_path(project_id, secret_id)
+        client.add_secret_version(request={"parent": parent, "payload": {"data": secret_data}})
+
+
+# @click.option("--project-id", required=True, help="The GCP project to add the secret to")
+@click.option("--username", required=False, multiple=True, type=str)
+@click.option("--generate-plaintext", type=bool, default=False, is_flag=True)
+@click.option("--generate-userlist", type=bool, default=False, is_flag=True)
+@click.option("--plaintext-k8s-secret", default="sentry-db-password", type=str)
+@click.option("--userlist-k8s-secret", default="service-pgbouncer", type=str)
+@click.option("--userlist-sm-secret-id", default="postgres", type=str)
+@click.pass_context
+def create_user(
+    ctx,
+    username,
+    generate_plaintext,
+    generate_userlist,
+    plaintext_k8s_secret,
+    userlist_k8s_secret,
+    userlist_sm_secret_id,
+):
+
+    project_id = ctx.obj.cluster.services_data['project']
+    client = kube_get_client()
+    api = CoreV1Api(client)
+
+    if not (generate_plaintext or generate_userlist):
+        print("Either --generate-plaintext or --generate-userlist should be specified.")
+        return
+
+    if generate_userlist and username:
+        print("You should not specify --username when using --generate-userlist")
+        return
+
+    # fetch current list of users
+    users = {}
+    secret_data = {}
+    try:
+        secret = api.read_namespaced_secret(namespace="default", name=plaintext_k8s_secret)
+        secret_data = secret.data
+    except ApiException as exc:
+        if exc.status != 404:
+            raise
+
+    for secret_item in secret_data:
+        password = standard_b64decode(secret_data[secret_item]).decode("utf-8")
+        users[secret_item] = {
+            "password": password,
+            "scram": pg_scram_sha256(password),
+        }
+
+    # Step 1: generate plaintext secrets
+    if generate_plaintext:
+        for user in username:
+            password = token_urlsafe(16)
+            users[user] = {
+                "password": password,
+                "scram": pg_scram_sha256(password),
+            }
+
+        upload_plaintext_to_k8s_secret(api, users, plaintext_k8s_secret)
+
+    # Step 2: generate userlists from plaintext secrets
+    if generate_userlist:
+        # removing plaintext passwords just to be more secure :muscle:
+        users = {k: {"scram": users[k]["scram"]} for k in users}
+
+        upload_userlist_to_k8s_secret(api, users, userlist_k8s_secret)
+        upload_userlist_to_google_secret(project_id, users, userlist_sm_secret_id)

--- a/sentry_kube/ext.py
+++ b/sentry_kube/ext.py
@@ -97,6 +97,7 @@ class PGBouncerSidecar(SimpleExtension):
         livenessProbe: Optional[dict] = None,
         resources: Optional[dict] = None,
         custom_pre_stop_command: Optional[str] = None,
+        use_auth: bool = False,
     ):
         if application_name:
             # Prepend supplied application_name to the pgbouncer options
@@ -122,31 +123,42 @@ class PGBouncerSidecar(SimpleExtension):
         if custom_pre_stop_command:
             pre_stop_command = custom_pre_stop_command
 
+        stats_users_statement = "stats_users = datadog\n"
+        userlist_init_cmd = ""
+        if not use_auth:
+            stats_users_statement = ""
+            userlist_init_cmd = """cat << EOF > /etc/pgbouncer/userlist.txt
+"postgres" ""
+"maintenance" ""
+EOF
+"""
+
         image = f"{repository}/pgbouncer:{version}"
         if ".pkg.dev/" in repository:
             image = f"{repository}/pgbouncer/image:{version}"
 
-        res = {
+        admin_user = "pgbouncer" if use_auth else "postgres"
+
+        res: dict[str, Any] = {
             "image": image,
             "name": "pgbouncer",
             "args": [
                 "/bin/sh",
                 "-ec",
-                f"""cat << EOF > /etc/pgbouncer/userlist.txt
-"postgres" ""
-"maintenance" ""
-EOF
-cat << EOF > /etc/pgbouncer.ini
+                userlist_init_cmd
+                + f"""cat << EOF > /etc/pgbouncer.ini
 [databases]
 {databases_str}
 [pgbouncer]
 listen_addr = 0.0.0.0
 listen_port = 6432
 unix_socket_dir =
-auth_type = trust
+auth_type = { "scram-sha-256" if use_auth else "trust" }
 auth_file = /etc/pgbouncer/userlist.txt
-admin_users = postgres
-pool_mode = transaction
+admin_users = {admin_user}
+"""
+                + stats_users_statement
+                + f"""pool_mode = transaction
 server_reset_query = DISCARD ALL
 ignore_startup_parameters = extra_float_digits
 server_check_query = select 1
@@ -181,6 +193,15 @@ exec su-exec pgbouncer pgbouncer /etc/pgbouncer.ini""",
         }
         _resources.update(resources or {})
         res["resources"] = _resources
+        if use_auth:
+            res["volumeMounts"] = [
+                {
+                    "name": "pgbouncer-secrets",
+                    "subPath": "userlist",
+                    "mountPath": "/etc/pgbouncer/userlist.txt",
+                    "readOnly": True,
+                }
+            ]
         if livenessProbe:
             res["livenessProbe"] = livenessProbe
         return json.dumps(res)


### PR DESCRIPTION
Sync from ops repo between SHA a864cafd6a4771434bab51c79b7773877c8342d7 and 134da6c507d2ee342575762cb3e47cc25b898767

Diff is as shown below
```shell
diff --git a/k8s/cli/requirements.in b/k8s/cli/requirements.in
index a191efc06..5e2d52e49 100644
--- a/k8s/cli/requirements.in
+++ b/k8s/cli/requirements.in
@@ -39,6 +39,8 @@ google-crc32c>=1.5.0
 # salt/generate_host_configs.py
 google-cloud-compute>=1.18.0
 google-cloud-os-login>=2.14.3
+# pg/create_user.py
+google-cloud-secret-manager>=2.20.2
 # bin/resize-disks
 rich
 # salt/states/redis-cluster/files/delete-keys.py
diff --git a/k8s/cli/requirements.txt b/k8s/cli/requirements.txt
index 7f674b769..03c89a642 100644
--- a/k8s/cli/requirements.txt
+++ b/k8s/cli/requirements.txt
@@ -44,6 +44,7 @@ google-api-core==2.20.0
     #   google-api-python-client
     #   google-cloud-compute
     #   google-cloud-os-login
+    #   google-cloud-secret-manager
 google-api-python-client==2.147.0
     # via -r k8s/cli/requirements.in
 google-auth==2.35.0
@@ -54,6 +55,7 @@ google-auth==2.35.0
     #   google-auth-httplib2
     #   google-cloud-compute
     #   google-cloud-os-login
+    #   google-cloud-secret-manager
     #   kubernetes
 google-auth-httplib2==0.2.0
     # via google-api-python-client
@@ -61,15 +63,22 @@ google-cloud-compute==1.19.2
     # via -r k8s/cli/requirements.in
 google-cloud-os-login==2.14.6
     # via -r k8s/cli/requirements.in
+google-cloud-secret-manager==2.20.2
+    # via -r k8s/cli/requirements.in
 google-crc32c==1.6.0
     # via -r k8s/cli/requirements.in
 googleapis-common-protos==1.65.0
     # via
     #   google-api-core
+    #   grpc-google-iam-v1
     #   grpcio-status
+grpc-google-iam-v1==0.13.1
+    # via google-cloud-secret-manager
 grpcio==1.66.1
     # via
     #   google-api-core
+    #   googleapis-common-protos
+    #   grpc-google-iam-v1
     #   grpcio-status
 grpcio-status==1.66.1
     # via google-api-core
@@ -127,12 +136,15 @@ proto-plus==1.24.0
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-os-login
+    #   google-cloud-secret-manager
 protobuf==5.28.2
     # via
     #   google-api-core
     #   google-cloud-compute
     #   google-cloud-os-login
+    #   google-cloud-secret-manager
     #   googleapis-common-protos
+    #   grpc-google-iam-v1
     #   grpcio-status
     #   proto-plus
 pyasn1==0.6.1
@@ -158,6 +170,7 @@ pyyaml==6.0.2
     #   -r k8s/cli/requirements.in
     #   kubernetes
     #   responses
+redis==5.1.1
     # via -r k8s/cli/requirements.in
 referencing==0.35.1
     # via
diff --git a/k8s/cli/sentry_kube/cli/pg/__init__.py b/k8s/cli/sentry_kube/cli/pg/__init__.py
new file mode 100644
index 000000000..16983dfaa
--- /dev/null
+++ b/k8s/cli/sentry_kube/cli/pg/__init__.py
@@ -0,0 +1,16 @@
+
+import click
+
+from . import create_user
+
+
+__all__ = ("pg",)
+
+
+
+@click.group()
+def pg():
+    pass
+
+
+pg.command(help=create_user.cmd_help)(create_user.create_user)
diff --git a/k8s/cli/sentry_kube/cli/pg/create_user.py b/k8s/cli/sentry_kube/cli/pg/create_user.py
new file mode 100644
index 000000000..546a609a2
--- /dev/null
+++ b/k8s/cli/sentry_kube/cli/pg/create_user.py
@@ -0,0 +1,317 @@
+import hmac
+import json
+from base64 import standard_b64decode, standard_b64encode
+from hashlib import pbkdf2_hmac, sha256
+from os import urandom
+from secrets import token_urlsafe
+
+import click
+from google.api_core import exceptions
+from google.cloud import secretmanager
+from kubernetes.client import CoreV1Api
+from kubernetes.client.rest import ApiException
+
+from libsentrykube.utils import kube_get_client
+
+# run this script only once per region.
+# this script generates and uploads the necessary username and passwords for postgres pgbouncer users.
+
+salt_size = 16
+digest_len = 32
+iterations = 4096
+
+
+cmd_help = """
+
+This command simplifies creation of users and corresponding userlist entries in the following
+places:
+
+- plaintext passwords in k8s secret `sentry-db-password`, to be used by the `getsentry` deployment,
+  `sentry` container;
+
+- userlist in k8s secret `service-pgbouncer`, to be used by intermediary and sidecar `pgbouncer`
+  containers;
+
+- userlist in GCP Secret Manager secret `postgres`, to be used by Salt on `db-*` instances.
+
+The script is addition-only. This is a safety net to avoid accidental user removal.
+
+
+## Step 1
+
+The first step generates plaintext passwords. You can specify several `--username` parameters if you
+want:
+
+\b
+```
+sentry-kube -C {env} pg create-user --generate-plaintext --username alice --username bob
+```
+
+The resulting password will be saved to `sentry-db-password` k8s secret (or you can override it with
+the `--plaintext-k8s-secret` option) as a separate secret entry:
+
+\b
+```
+apiVersion: v1
+data:
+  alice: YWFh
+  bob: YmJi
+kind: Secret
+```
+
+## Step 2
+
+After plaintext secrets populated, it is possible to generate userlist entries out of them. There is
+no need to specify usernames, as they will be taken from the plaintext k8s secret.
+
+\b
+```
+sentry-kube -C {env} pg create-user --generate-userlist
+```
+
+This will update userlists both in k8s secrets and Secret Manager.
+
+
+## Maintenance
+
+> [!WARNING]
+> Proceed with caution. This may start an incident if used carelessly.
+
+If you really want to delete users, you can do so with standard commands:
+
+\b
+```
+sentry-kube -q -C s4s kubectl edit secrets sentry-db-password
+sentry-kube -q -C s4s edit-secret sentry-db-password
+sentry-kube -q -C s4s edit-secret service-pgbouncer
+```
+
+"""
+
+
+
+def b64enc(b: bytes) -> str:
+    return standard_b64encode(b).decode("utf-8")
+
+
+def pg_scram_sha256(passwd: str) -> str:
+    salt = urandom(salt_size)
+    digest_key = pbkdf2_hmac("sha256", passwd.encode("utf8"), salt, iterations, digest_len)
+    client_key = hmac.digest(digest_key, "Client Key".encode("UTF-8"), "sha256")
+    stored_key = sha256(client_key).digest()
+    server_key = hmac.digest(digest_key, "Server Key".encode("UTF-8"), "sha256")
+    return (
+        f"SCRAM-SHA-256${iterations}:{b64enc(salt)}" f"${b64enc(stored_key)}:{b64enc(server_key)}"
+    )
+
+
+def decode_userlist(userlist: str):
+    # userlist is a base64 encoded list of users and their passwords.
+    # the format is as follows:
+    # "user1" "SCRAM-SHA-256...."
+    # "user2" "SCRAM-SHA-256...."
+    hashes = {}
+    for line in userlist.rstrip("\n").split("\n"):
+        (username, password_string) = line.split(" ")
+        username = username.replace('"', "")
+        password_string = password_string.replace('"', "")
+        hashes[username] = password_string
+    return hashes
+
+
+def upload_plaintext_to_k8s_secret(
+    api: CoreV1Api,
+    users: dict[str, dict[str, str]],
+    secret_name: str
+) -> None:
+    # TODO: create if not exists
+    # api.create_namespaced_secret(namespace, body)
+
+    secret = api.read_namespaced_secret(namespace="default", name=secret_name)
+    print(f"### Kubernetes secret `default/{secret_name}`, BEFORE")
+    for secret_item in secret.data:
+        print(f"{secret_item}: {secret.data[secret_item]}")
+    print()
+
+    is_modified = False
+    for user in users:
+        if user not in secret.data:
+            secret.data[user] = b64enc(users[user]["password"].encode("utf-8"))
+            is_modified = True
+
+    if not is_modified:
+        print(f"Kubernetes secret `default/{secret_name}` is up to date. No new users.")
+        return
+    print(f"### Kubernetes secret `default/{secret_name}`, AFTER")
+    for secret_item in secret.data:
+        print(f"{secret_item}: {secret.data[secret_item]}")
+    print()
+
+    confirm = input("Type 'yes' to apply: ")
+    if confirm != "yes":
+        print("WARNING: This change was not applied.")
+        return
+
+    api.patch_namespaced_secret(namespace="default", name=secret_name, body={"data": secret.data})
+
+
+def merge_userlists(encoded_userlist: str, users: dict[str, dict[str, str]], label: str):
+    userlist = standard_b64decode(encoded_userlist).decode("utf-8")
+
+    print(f"### {label}, BEFORE")
+    print(userlist)
+    print()
+
+    hashes = decode_userlist(userlist)
+
+    is_modified = False
+    for user in users:
+        if user not in hashes:
+            hashes[user] = users[user]["scram"]
+            is_modified = True
+
+    if not is_modified:
+        print(f"{label} is up to date. No new users.\n")
+        return
+
+    userlist = ""
+    for entry in hashes:
+        userlist += f'"{entry}" "{hashes[entry]}"\n'
+
+    print(f"### {label}, AFTER")
+    print(userlist)
+    print()
+
+    confirm = input("Type 'yes' to apply: ")
+    if confirm != "yes":
+        print("WARNING: This change was not applied.")
+        return
+
+    encoded_userlist = standard_b64encode(userlist.encode("utf-8")).decode("utf-8")
+    return encoded_userlist
+
+
+def upload_userlist_to_k8s_secret(
+    api: CoreV1Api,
+    users: dict[str,
+    dict[str, str]],
+    secret_name: str
+) -> None:
+    # TODO: create if not exists
+    # api.create_namespaced_secret(namespace, body)
+
+    secret = api.read_namespaced_secret(namespace="default", name=secret_name)
+    encoded_userlist = secret.data["userlist"]
+    merged_userlist = merge_userlists(
+        encoded_userlist, users, f"Kubernetes secret `default/{secret_name}`"
+    )
+    if merged_userlist:
+        api.patch_namespaced_secret(
+            namespace="default",
+            name=secret_name,
+            body={"data": {"userlist": merged_userlist}},
+        )
+
+
+def upload_userlist_to_google_secret(
+    project_id: str,
+    users: dict[str, dict[str, str]],
+    secret_id: str
+) -> None:
+    # run gcloud auth application-default login for the gcloud python lib
+
+    # Create the Secret Manager client.
+    client = secretmanager.SecretManagerServiceClient()
+
+    data = {"userlist": ""}
+
+    # get the current secret to ensure we're not double adding
+    version_id = "latest"
+    name = f"projects/{project_id}/secrets/{secret_id}/versions/{version_id}"
+    try:
+        response = client.access_secret_version(request={"name": name})
+        payload = response.payload.data.decode("utf-8")
+        data = json.loads(payload)
+    except exceptions.NotFound:
+        print(
+            f"ERROR: The secret `{secret_id}` should be created with Terragrunt before running this script."
+        )
+        return
+
+    # decode the userlist
+    encoded_userlist = data["userlist"]
+    merged_userlist = merge_userlists(
+        encoded_userlist, users, f"Secret Manager secret `{secret_id}`"
+    )
+    if merged_userlist:
+        data["userlist"] = merged_userlist
+        secret_data = json.dumps(data).encode("utf-8")
+        parent = client.secret_path(project_id, secret_id)
+        client.add_secret_version(request={"parent": parent, "payload": {"data": secret_data}})
+
+
+# @click.option("--project-id", required=True, help="The GCP project to add the secret to")
+@click.option("--username", required=False, multiple=True, type=str)
+@click.option("--generate-plaintext", type=bool, default=False, is_flag=True)
+@click.option("--generate-userlist", type=bool, default=False, is_flag=True)
+@click.option("--plaintext-k8s-secret", default="sentry-db-password", type=str)
+@click.option("--userlist-k8s-secret", default="service-pgbouncer", type=str)
+@click.option("--userlist-sm-secret-id", default="postgres", type=str)
+@click.pass_context
+def create_user(
+    ctx,
+    username,
+    generate_plaintext,
+    generate_userlist,
+    plaintext_k8s_secret,
+    userlist_k8s_secret,
+    userlist_sm_secret_id,
+):
+
+    project_id = ctx.obj.cluster.services_data['project']
+    client = kube_get_client()
+    api = CoreV1Api(client)
+
+    if not (generate_plaintext or generate_userlist):
+        print("Either --generate-plaintext or --generate-userlist should be specified.")
+        return
+
+    if generate_userlist and username:
+        print("You should not specify --username when using --generate-userlist")
+        return
+
+    # fetch current list of users
+    users = {}
+    secret_data = {}
+    try:
+        secret = api.read_namespaced_secret(namespace="default", name=plaintext_k8s_secret)
+        secret_data = secret.data
+    except ApiException as exc:
+        if exc.status != 404:
+            raise
+
+    for secret_item in secret_data:
+        password = standard_b64decode(secret_data[secret_item]).decode("utf-8")
+        users[secret_item] = {
+            "password": password,
+            "scram": pg_scram_sha256(password),
+        }
+
+    # Step 1: generate plaintext secrets
+    if generate_plaintext:
+        for user in username:
+            password = token_urlsafe(16)
+            users[user] = {
+                "password": password,
+                "scram": pg_scram_sha256(password),
+            }
+
+        upload_plaintext_to_k8s_secret(api, users, plaintext_k8s_secret)
+
+    # Step 2: generate userlists from plaintext secrets
+    if generate_userlist:
+        # removing plaintext passwords just to be more secure :muscle:
+        users = {k: {"scram": users[k]["scram"]} for k in users}
+
+        upload_userlist_to_k8s_secret(api, users, userlist_k8s_secret)
+        upload_userlist_to_google_secret(project_id, users, userlist_sm_secret_id)
diff --git a/k8s/cli/sentry_kube/ext.py b/k8s/cli/sentry_kube/ext.py
index 913e1b8b1..fd8ce9997 100644
--- a/k8s/cli/sentry_kube/ext.py
+++ b/k8s/cli/sentry_kube/ext.py
@@ -97,6 +97,7 @@ class PGBouncerSidecar(SimpleExtension):
         livenessProbe: Optional[dict] = None,
         resources: Optional[dict] = None,
         custom_pre_stop_command: Optional[str] = None,
+        use_auth: bool = False,
     ):
         if application_name:
             # Prepend supplied application_name to the pgbouncer options
@@ -122,31 +123,42 @@ class PGBouncerSidecar(SimpleExtension):
         if custom_pre_stop_command:
             pre_stop_command = custom_pre_stop_command
 
+        stats_users_statement = "stats_users = datadog\n"
+        userlist_init_cmd = ""
+        if not use_auth:
+            stats_users_statement = ""
+            userlist_init_cmd = """cat << EOF > /etc/pgbouncer/userlist.txt
+"postgres" ""
+"maintenance" ""
+EOF
+"""
+
         image = f"{repository}/pgbouncer:{version}"
         if ".pkg.dev/" in repository:
             image = f"{repository}/pgbouncer/image:{version}"
 
-        res = {
+        admin_user = "pgbouncer" if use_auth else "postgres"
+
+        res: dict[str, Any] = {
             "image": image,
             "name": "pgbouncer",
             "args": [
                 "/bin/sh",
                 "-ec",
-                f"""cat << EOF > /etc/pgbouncer/userlist.txt
-"postgres" ""
-"maintenance" ""
-EOF
-cat << EOF > /etc/pgbouncer.ini
+                userlist_init_cmd
+                + f"""cat << EOF > /etc/pgbouncer.ini
 [databases]
 {databases_str}
 [pgbouncer]
 listen_addr = 0.0.0.0
 listen_port = 6432
 unix_socket_dir =
-auth_type = trust
+auth_type = { "scram-sha-256" if use_auth else "trust" }
 auth_file = /etc/pgbouncer/userlist.txt
-admin_users = postgres
-pool_mode = transaction
+admin_users = {admin_user}
+"""
+                + stats_users_statement
+                + f"""pool_mode = transaction
 server_reset_query = DISCARD ALL
 ignore_startup_parameters = extra_float_digits
 server_check_query = select 1
@@ -181,6 +193,15 @@ exec su-exec pgbouncer pgbouncer /etc/pgbouncer.ini""",
         }
         _resources.update(resources or {})
         res["resources"] = _resources
+        if use_auth:
+            res["volumeMounts"] = [
+                {
+                    "name": "pgbouncer-secrets",
+                    "subPath": "userlist",
+                    "mountPath": "/etc/pgbouncer/userlist.txt",
+                    "readOnly": True,
+                }
+            ]
         if livenessProbe:
             res["livenessProbe"] = livenessProbe
         return json.dumps(res)

```