### PR TITLE
feat(devenv): Use devenv for setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,22 @@
 #!/bin/bash
 # shellcheck disable=SC1091
 
-if [ ! -d .venv ]; then
+export SENTRY_DEVENV_HOME="${SENTRY_DEVENV_HOME:-$HOME/.local/share/sentry-devenv}"
+PATH_add "${SENTRY_DEVENV_HOME}/bin"
+
+if ! [[ "${SENTRY_INFRATOOLS_DEVENV_OPTOUT:-}" ]] && command -v devenv >/dev/null; then
+    # if devenv is installed, we use it
+    echo "Using devenv. To opt out, set SENTRY_INFRATOOLS_DEVENV_OPTOUT to any value in your .env"
+    if ! [ -f .venv/bin/activate ]; then
+        devenv sync
+    fi
+    # Don't need to source anything as things like sentry-kube and salt
+    # running in their own virtualenvs are linked to in here.
+    PATH_add "${PWD}/.devenv/bin"
+
+    PATH_add "${PWD}/.venv/bin"
+    export VIRTUAL_ENV="${PWD}/.venv"
+elif [ ! -d .venv ]; then
     echo "warning: creating virtualenv for the first time"
     if which pyenv > /dev/null; then
         eval "$(pyenv init -)"

--- a/devenv/config.ini
+++ b/devenv/config.ini
@@ -1,0 +1,18 @@
+[venv.sentry-infra-tools]
+python = 3.11.6
+path = .venv
+requirements = requirements-dev.txt
+editable =
+    .
+# no need for bins; this is our primary venv
+# and it's sourced by .envrc
+
+[python3.11.6]
+darwin_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-x86_64-apple-darwin-install_only.tar.gz
+darwin_x86_64_sha256 = 178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371
+darwin_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-apple-darwin-install_only.tar.gz
+darwin_arm64_sha256 = 916c35125b5d8323a21526d7a9154ca626453f63d0878e95b9f613a95006c990
+linux_x86_64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-x86_64-unknown-linux-gnu-install_only.tar.gz
+linux_x86_64_sha256 = ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8
+linux_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-unknown-linux-gnu-install_only.tar.gz
+linux_arm64_sha256 = 3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from devenv.lib import config, venv
+
+
+def main(context: dict[str, str]) -> int:
+    repo = context["repo"]
+    reporoot = context["reporoot"]
+
+    venv_dir, python_version, requirements, editable_paths, bins = venv.get(
+        reporoot, repo
+    )
+    url, sha256 = config.get_python(reporoot, python_version)
+    print(f"ensuring {repo} venv at {venv_dir}...")
+    venv.ensure(venv_dir, python_version, url, sha256)
+
+    print(f"syncing {repo} with {requirements}...")
+    venv.sync(reporoot, venv_dir, requirements, editable_paths, bins)
+
+    return 0


### PR DESCRIPTION
Lets move towards using devenv for setting up the development environment since too many ways of setting dev environment was cited as one of the concerns when working with too many repos.

```shell
 ~/w/sentry-infra-tools  nikhars/feat/devenv ?2  rm -rf .venv/
 ~/w/sentry-infra-tools  nikhars/feat/devenv ?2  devenv sync
ensuring sentry-infra-tools venv at .venv...
virtualenv doesn't exist or is using an outdated python, recreating at .venv...
syncing sentry-infra-tools with /Users/nikharsaxena/workspace/sentry-infra-tools/requirements-dev.txt...
 ~/w/sentry-infra-tools  nikhars/feat/devenv ?2  make tools-test
pytest -vv .
============================================= test session starts =============================================
platform darwin -- Python 3.11.6, pytest-8.3.3, pluggy-1.5.0 -- /Users/nikharsaxena/workspace/sentry-infra-tools/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/nikharsaxena/workspace/sentry-infra-tools
configfile: pyproject.toml
plugins: anyio-4.4.0
collected 106 items

assistant/test_prdocs.py::test_empty PASSED                                                             [  0%]
assistant/test_prdocs.py::test_full_message PASSED                                                      [  1%]
config_builder/merger/test_libsonnet.py::test_order PASSED                                              [  2%]
config_builder/merger/test_yaml.py::test_merger PASSED                                                  [  3%]
config_builder/test_combined_generator.py::test_generated_libsonnet_file_content PASSED                 [  4%]
config_builder/test_combined_generator.py::test_generated_json_content PASSED                           [  5%]
config_builder/test_combined_generator.py::test_iteration PASSED                                        [  6%]
config_builder/test_combined_generator.py::test_combine_all[Combining libsonnet files] PASSED           [  7%]
config_builder/test_combined_generator.py::test_combine_all[Combining yaml files] PASSED                [  8%]
config_builder/test_combined_generator.py::test_cleanup PASSED                                          [  9%]
config_builder/test_json_schema_validator.py::test_json_schema_validator[Validate valid yaml file (regional override)] PASSED [ 10%]
config_builder/test_json_schema_validator.py::test_json_schema_validator[Validate valid yaml file (default consumer group)] PASSED [ 11%]
config_builder/test_json_schema_validator.py::test_json_schema_validator[Unrelated directory should not be validated] PASSED [ 12%]
config_builder/test_json_schema_validator.py::test_json_schema_validator[Unrelated subdirectory should not be validated] PASSED [ 13%]
config_builder/test_json_schema_validator.py::test_json_schema_invalid[Invalid yaml file should fail correctly (wrong type in ref)] PASSED [ 14%]
config_builder/test_json_schema_validator.py::test_json_schema_invalid[Invalid yaml file should fail correctly (extra key)] PASSED [ 15%]
config_builder/test_json_schema_validator.py::test_json_schema_invalid[Invalid yaml file should fail correctly (missing required)] PASSED [ 16%]
config_builder/test_materializer.py::test_iteration PASSED                                              [ 16%]
config_builder/test_materializer.py::test_materialize_file[Put the materialized file in an arbitrary directory0] PASSED [ 17%]
config_builder/test_materializer.py::test_materialize_file[Put the materialized file in an arbitrary directory1] PASSED [ 18%]
config_builder/test_materializer.py::test_materialize_file[Yaml file] PASSED                            [ 19%]
libsentrykube/tests/kubectl/test_important_diffs.py::test_process_data PASSED                           [ 20%]
libsentrykube/tests/test_cluster.py::test_clusters_load[Load cluster template] PASSED                   [ 21%]
libsentrykube/tests/test_cluster.py::test_fail_load PASSED                                              [ 22%]
libsentrykube/tests/test_cluster.py::test_list_clusters PASSED                                          [ 23%]
libsentrykube/tests/test_cluster.py::test_list_clusters_for_customer PASSED                             [ 24%]
libsentrykube/tests/test_config.py::test_config_load PASSED                                             [ 25%]
libsentrykube/tests/test_context.py::test_init PASSED                                                   [ 26%]
libsentrykube/tests/test_customer.py::test_config_load PASSED                                           [ 27%]
libsentrykube/tests/test_datadog.py::test_check_monitor_ok PASSED                                       [ 28%]
libsentrykube/tests/test_datadog.py::test_check_monitor_missing_overall_state PASSED                    [ 29%]
libsentrykube/tests/test_datadog.py::test_check_monitor_bad_http_response PASSED                        [ 30%]
libsentrykube/tests/test_deep_merge.py::test_basic_merge PASSED                                         [ 31%]
libsentrykube/tests/test_deep_merge.py::test_extra_keys_into PASSED                                     [ 32%]
libsentrykube/tests/test_deep_merge.py::test_extra_keys_other PASSED                                    [ 33%]
libsentrykube/tests/test_deep_merge.py::test_basic_no_overwrite PASSED                                  [ 33%]
libsentrykube/tests/test_deep_merge.py::test_deep_merge_double_dict_with_overwrite PASSED               [ 34%]
libsentrykube/tests/test_deep_merge.py::test_deep_merge_double_dict_no_overwrite PASSED                 [ 35%]
libsentrykube/tests/test_ext.py::test_build_annotation_data_invalid_id PASSED                           [ 36%]
libsentrykube/tests/test_ext.py::test_build_label_data_invalid_id PASSED                                [ 37%]
libsentrykube/tests/test_ext.py::test_build_annotation_data_symbolicator PASSED                         [ 38%]
libsentrykube/tests/test_ext.py::test_build_label_data_symbolicator PASSED                              [ 39%]
libsentrykube/tests/test_ext.py::test_format_docs_empty PASSED                                          [ 40%]
libsentrykube/tests/test_ext.py::test_format_docs_single PASSED                                         [ 41%]
libsentrykube/tests/test_ext.py::test_format_docs_multi PASSED                                          [ 42%]
libsentrykube/tests/test_ext.py::test_format_people_empty PASSED                                        [ 43%]
libsentrykube/tests/test_ext.py::test_format_people_single PASSED                                       [ 44%]
libsentrykube/tests/test_ext.py::test_format_people_multi PASSED                                        [ 45%]
libsentrykube/tests/test_ext.py::test_format_slack_channels_empty PASSED                                [ 46%]
libsentrykube/tests/test_ext.py::test_format_slack_channels_single PASSED                               [ 47%]
libsentrykube/tests/test_ext.py::test_format_slack_channels_multi PASSED                                [ 48%]
libsentrykube/tests/test_ext.py::test_format_slos_empty PASSED                                          [ 49%]
libsentrykube/tests/test_ext.py::test_format_slos_single PASSED                                         [ 50%]
libsentrykube/tests/test_ext.py::test_format_slos_multi PASSED                                          [ 50%]
libsentrykube/tests/test_ext.py::test_format_teams_empty PASSED                                         [ 51%]
libsentrykube/tests/test_ext.py::test_format_teams_single PASSED                                        [ 52%]
libsentrykube/tests/test_ext.py::test_format_teams_multi PASSED                                         [ 53%]
libsentrykube/tests/test_ext.py::test_format_teams_no_tags PASSED                                       [ 54%]
libsentrykube/tests/test_ext.py::test_format_teams_single_tag PASSED                                    [ 55%]
libsentrykube/tests/test_ext.py::test_format_teams_multi_tags PASSED                                    [ 56%]
libsentrykube/tests/test_gcloud.py::test_get_channel_versions_success PASSED                            [ 57%]
libsentrykube/tests/test_gcloud.py::test_get_channel_versions_bad_response PASSED                       [ 58%]
libsentrykube/tests/test_jira.py::test_create_issue_success PASSED                                      [ 59%]
libsentrykube/tests/test_jira.py::test_create_issue_failure PASSED                                      [ 60%]
libsentrykube/tests/test_jira.py::test_update_ticket_success PASSED                                     [ 61%]
libsentrykube/tests/test_jira.py::test_update_ticket_failure PASSED                                     [ 62%]
libsentrykube/tests/test_jira.py::test_find_jira_issue_success PASSED                                   [ 63%]
libsentrykube/tests/test_jira.py::test_find_jira_issue_not_found PASSED                                 [ 64%]
libsentrykube/tests/test_jira.py::test_find_jira_issue_failure PASSED                                   [ 65%]
libsentrykube/tests/test_jira.py::test_create_comment_success PASSED                                    [ 66%]
libsentrykube/tests/test_jira.py::test_create_comment_failure PASSED                                    [ 66%]
libsentrykube/tests/test_kube.py::test_consolidate_variables_not_external PASSED                        [ 67%]
libsentrykube/tests/test_lint.py::test_lint PASSED                                                      [ 68%]
libsentrykube/tests/test_lint.py::test_kubelinter_config PASSED                                         [ 69%]
libsentrykube/tests/test_lint.py::test_kubelinter_config_file_cluster PASSED                            [ 70%]
libsentrykube/tests/test_reversemap.py::test_trie[Empty trie] PASSED                                    [ 71%]
libsentrykube/tests/test_reversemap.py::test_trie[Path outside of the trie] PASSED                      [ 72%]
libsentrykube/tests/test_reversemap.py::test_trie[Incomplete path] PASSED                               [ 73%]
libsentrykube/tests/test_reversemap.py::test_trie[Contains exact path] PASSED                           [ 74%]
libsentrykube/tests/test_reversemap.py::test_trie[Contains subpath] PASSED                              [ 75%]
libsentrykube/tests/test_reversemap.py::test_trie[Incomplete path - multiple levels] PASSED             [ 76%]
libsentrykube/tests/test_reversemap.py::test_trie[Multi level, subpath present] PASSED                  [ 77%]
libsentrykube/tests/test_reversemap.py::test_trie[Multi level, exact path] PASSED                       [ 78%]
libsentrykube/tests/test_reversemap.py::test_resource_index[One existing service in one cluster] PASSED [ 79%]
libsentrykube/tests/test_reversemap.py::test_resource_index[One existing service in four clusters] PASSED [ 80%]
libsentrykube/tests/test_reversemap.py::test_resource_index[One existing service in four clusters, exact path] PASSED [ 81%]
libsentrykube/tests/test_reversemap.py::test_resource_index[One symlinked service in multiple clusters] PASSED [ 82%]
libsentrykube/tests/test_reversemap.py::test_merge_references PASSED                                    [ 83%]
libsentrykube/tests/test_service.py::test_get_service_values_not_external PASSED                        [ 83%]
libsentrykube/tests/test_service.py::test_get_service_values_external PASSED                            [ 84%]
libsentrykube/tests/test_service.py::test_get_service_value_overrides_present PASSED                    [ 85%]
libsentrykube/tests/test_service.py::test_get_service_value_overrides_missing PASSED                    [ 86%]
libsentrykube/tests/test_service.py::test_get_service_data_present PASSED                               [ 87%]
pr_approver/test_approver.py::test_approver PASSED                                                      [ 88%]
pr_approver/test_rules.py::test_decision[Same value in same value out] PASSED                           [ 89%]
pr_approver/test_rules.py::test_decision[Approve wins over Ignore] PASSED                               [ 90%]
pr_approver/test_rules.py::test_decision[Decline wins over Ignore] PASSED                               [ 91%]
pr_approver/test_rules.py::test_decision[Decline wins over Approve] PASSED                              [ 92%]
pr_approver/test_rules.py::test_approval[Adding services does not require review] PASSED                [ 93%]
pr_approver/test_rules.py::test_approval[Removing tier 0 service requires review] PASSED                [ 94%]
pr_approver/test_rules.py::test_approval[Removing tier 3 service does not require review] PASSED        [ 95%]
pr_approver/test_rules.py::test_approval[Bumping up tier requires review] PASSED                        [ 96%]
pr_approver/test_rules.py::test_approval[Abandoning service requires review] PASSED                     [ 97%]
pr_approver/test_rules.py::test_approval[Removing one team without abandoning service does not require review] PASSED [ 98%]
pr_approver/test_rules.py::test_approval[Removing slack channel requires review] PASSED                 [ 99%]
pr_approver/test_rules.py::test_approval[Changing name does not require review] PASSED                  [100%]

============================================= 106 passed in 2.18s =============================================
```