### PR TITLE
fix(service-registry): Use the correct path to find JSON file

### DIFF
--- a/libsentrykube/tests/test_utils.py
+++ b/libsentrykube/tests/test_utils.py
@@ -1,17 +1,20 @@
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from libsentrykube.utils import get_service_registry_filepath, workspace_root
 
 
-@patch("importlib.import_module", return_value='/')
+@patch("importlib.import_module", return_value="/")
 @patch("importlib.resources.files", return_value=Path("a/b/c"))
 def test_get_service_registry_package_installed(
-    mock_import_module, 
-    mock_import_resources_path
+    mock_import_module, mock_import_resources_path
 ):
-    assert get_service_registry_filepath() == Path("a/b/c/sentry_service_registry/services.json")
+    assert get_service_registry_filepath() == Path(
+        "a/b/c/config/combined/service_registry.json"
+    )
 
 
 def test_get_service_registry_package_not_installed():
     root = str(workspace_root())
-    assert get_service_registry_filepath() == Path(f"{root}/shared_config/_materialized_configs/service_registry/combined/service_registry.json")
+    assert get_service_registry_filepath() == Path(
+        f"{root}/shared_config/_materialized_configs/service_registry/combined/service_registry.json"
+    )

--- a/libsentrykube/utils.py
+++ b/libsentrykube/utils.py
@@ -1,6 +1,7 @@
 import copy
 import hashlib
 import importlib
+import importlib.resources
 import json
 import os
 import platform
@@ -400,8 +401,10 @@ def get_service_registry_filepath() -> Path:
     service_registry_pkg_name = "sentry_service_registry"
     try:
         importlib.import_module(service_registry_pkg_name)
-        path = str(importlib.resources.files(service_registry_pkg_name).joinpath(''))
-        return Path(path) / "sentry_service_registry" / "services.json"
+        path = str(importlib.resources.files(service_registry_pkg_name).joinpath(""))
+        return Path(path) / "config" / "combined" / "service_registry.json"
     except ImportError:
         root = workspace_root()
-        return Path(f"{root}/shared_config/_materialized_configs/service_registry/combined/service_registry.json")
+        return Path(
+            f"{root}/shared_config/_materialized_configs/service_registry/combined/service_registry.json"
+        )


### PR DESCRIPTION
We were looking at the wrong path when looking for the JSON file