### PR TITLE
fix: --quiet should mute DD echos

### DIFF
--- a/libsentrykube/events.py
+++ b/libsentrykube/events.py
@@ -35,7 +35,7 @@ def ensure_datadog_api_key_set() -> None:
         )
 
 
-def send_event_payload_to_datadog(payload) -> None:
+def send_event_payload_to_datadog(payload: dict, quiet: bool = False) -> None:
     # API docs: https://docs.datadoghq.com/api/latest/events/#post-an-event
     res = httpx.post(
         f"{DD_API_BASE}/api/v1/events",
@@ -45,11 +45,14 @@ def send_event_payload_to_datadog(payload) -> None:
         json=payload,
     )
     res.raise_for_status()
-    click.echo("\nReported the action to DataDog events:")
-    click.echo(res.json()["event"]["url"])
+    if not quiet:
+        click.echo("\nReported the action to DataDog events:")
+        click.echo(res.json()["event"]["url"])
 
 
-def report_event_to_datadog(title: str, text: str, tags: dict) -> None:
+def report_event_to_datadog(
+    title: str, text: str, tags: dict, quiet: bool = False
+) -> None:
     payload = {
         "title": title,
         "text": text,
@@ -57,7 +60,7 @@ def report_event_to_datadog(title: str, text: str, tags: dict) -> None:
         "date_happened": int(time.time()),
         "alert_type": "user_update",
     }
-    return send_event_payload_to_datadog(payload)
+    return send_event_payload_to_datadog(payload, quiet)
 
 
 def _markdown_text(text: str) -> str:
@@ -72,6 +75,7 @@ def _get_sentry_region(customer_name: str) -> str:
 def report_terragrunt_event(
     cli_args: str,
     extra_tags: Optional[dict] = None,
+    quiet: bool = False,
 ) -> None:
     # Find our slice under terragrunt/terraform
     if "terraform/" in os.getcwd():
@@ -110,6 +114,7 @@ def report_terragrunt_event(
             f"User **{user}** ran terragrunt '{cli_args}' for slice: **{tgslice}** "
         ),
         tags=tags,
+        quiet=quiet,
     )
 
 
@@ -120,6 +125,7 @@ def report_event_for_service(
     service_name: str = "",
     secret_name: str = "",
     extra_tags: Optional[dict] = None,
+    quiet: bool = False,
 ) -> None:
     user = getpass.getuser()
     sentry_region = _get_sentry_region(customer_name)
@@ -193,6 +199,7 @@ def report_event_for_service(
             f"Command line: `{command_line}`"
         ),
         tags=tags,
+        quiet=quiet,
     )
 
 
@@ -202,6 +209,7 @@ def report_event_for_service_list(
     operation: str,
     services: List[str],
     extra_tags: Optional[dict] = None,
+    quiet: bool = False,
 ) -> None:
     for service in services:
         report_event_for_service(
@@ -210,4 +218,5 @@ def report_event_for_service_list(
             operation=operation,
             service_name=service,
             extra_tags=copy.deepcopy(extra_tags),
+            quiet=quiet,
         )

--- a/sentry_kube/cli/apply.py
+++ b/sentry_kube/cli/apply.py
@@ -414,7 +414,14 @@ def apply(
         if not soak_only:
             click.secho("\nStarting by deploying to canaries only first.\n")
             canary_applied = _apply(
-                ctx, services, yes, filters, server_side, important_diffs_only, True
+                ctx,
+                services,
+                yes,
+                filters,
+                server_side,
+                important_diffs_only,
+                True,
+                quiet=ctx.obj.quiet_mode,
             )
 
         has_soaked = False
@@ -464,7 +471,16 @@ def apply(
                     )
 
     # Deploy to all if we confirm to proceed
-    _apply(ctx, services, yes, filters, server_side, important_diffs_only, False)
+    _apply(
+        ctx,
+        services,
+        yes,
+        filters,
+        server_side,
+        important_diffs_only,
+        False,
+        quiet=ctx.obj.quiet_mode,
+    )
 
 
 def _apply(
@@ -475,6 +491,7 @@ def _apply(
     server_side,
     important_diffs_only: bool,
     use_canary: bool,
+    quiet: bool = False,
 ) -> bool:
     """
     Apply a service(s) to production, using a basic confirmation wrapper around
@@ -521,7 +538,11 @@ def _apply(
     child_process.communicate(definitions)
     try:
         report_event_for_service_list(
-            customer_name, ctx.obj.cluster_name, operation="apply", services=services
+            customer_name,
+            ctx.obj.cluster_name,
+            operation="apply",
+            services=services,
+            quiet=quiet,
         )
     except Exception as e:
         click.echo("!! Could not report an event to DataDog:")

--- a/sentry_kube/cli/edit_secret.py
+++ b/sentry_kube/cli/edit_secret.py
@@ -95,6 +95,7 @@ def edit_secret(ctx, secret_name, namespace, no_backup):
             ctx.obj.cluster_name,
             operation="edit-secret",
             secret_name=secret_name,
+            quiet=ctx.obj.quiet_mode,
         )
     except Exception as e:
         click.echo("!! Could not report an event to DataDog:")

--- a/sentry_kube/cli/kubectl.py
+++ b/sentry_kube/cli/kubectl.py
@@ -89,6 +89,7 @@ def kubectl(ctx, quiet, yes):
                     ctx.obj.cluster_name,
                     operation=f"kubectl {recordable_token}",
                     service_name="kubectl",
+                    quiet=ctx.obj.quiet_mode,
                 )
             except Exception as e:
                 click.echo("!! Could not report an event to DataDog:")

--- a/sentry_kube/cli/run_job.py
+++ b/sentry_kube/cli/run_job.py
@@ -119,6 +119,7 @@ def run_job(ctx, job_name, arg, kwarg, service_name, yes, quiet):
                         ctx.obj.cluster_name,
                         operation=f"run-job {job_name}",
                         service_name=service_name,
+                        quiet=ctx.obj.quiet_mode,
                     )
                 except Exception as e:
                     click.echo("!! Could not report an event to DataDog:")

--- a/sentry_kube/cli/run_pod.py
+++ b/sentry_kube/cli/run_pod.py
@@ -364,6 +364,7 @@ def run_pod(
             ctx.obj.cluster_name,
             operation="run-pod",
             service_name=service,
+            quiet=ctx.obj.quiet_mode,
         )
     except Exception as e:
         click.echo("!! Could not report an event to DataDog:")


### PR DESCRIPTION
`--quiet` currently doesn't apply to DD reporting, it should so that we can pipe output from `sentry-kube` (mainly `kubectl`) into other things.