### PR TITLE
Introduce an added override file to be managed by tools

### DIFF
--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -20,7 +20,7 @@ from libsentrykube.service import (
     get_service_template_files,
     get_service_values,
     get_service_value_overrides,
-    get_managed_service_value_overrides,
+    get_tools_managed_service_value_overrides,
 )
 from libsentrykube.utils import (
     deep_merge_dict,
@@ -126,7 +126,7 @@ def _consolidate_variables(
     deep_merge_dict(service_values, service_value_overrides)
 
     # Override files managed by tools
-    managed_values = get_managed_service_value_overrides(
+    managed_values = get_tools_managed_service_value_overrides(
         service_name, customer_name, cluster_name, external
     )
     deep_merge_dict(service_values, managed_values)

--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -20,6 +20,7 @@ from libsentrykube.service import (
     get_service_template_files,
     get_service_values,
     get_service_value_overrides,
+    get_managed_service_value_overrides,
 )
 from libsentrykube.utils import (
     deep_merge_dict,
@@ -100,6 +101,21 @@ def _consolidate_variables(
     cluster_name: str = "default",
     external: bool = False,
 ) -> dict:
+    """
+    We have multiple levels of overrides for our value files.
+    1. The values defined inside the service directory as values.yaml.
+    2. overridden by the regional overrides in
+       `service/region_override/region/cluster.yaml`
+    3. overridden by the managed override file. This is like point 2. Conceptually
+       there is no difference, practically this is managed by tools while region
+       overrides are managed manually and they can contain comments. Tools cannot
+       preserve comments.
+    4. overridden by the cluster file. Which is likely going to be replaced by 2 and 3.
+
+    TODO: write the minimum components of a yaml parser to remove step 3 and
+          patch the regional override preserving comments.
+    """
+
     # Service defaults from _values
     service_values = get_service_values(service_name, external)
 
@@ -108,6 +124,12 @@ def _consolidate_variables(
         service_name, customer_name, cluster_name, external
     )
     deep_merge_dict(service_values, service_value_overrides)
+
+    # Override files managed by tools
+    managed_values = get_managed_service_value_overrides(
+        service_name, customer_name, cluster_name, external
+    )
+    deep_merge_dict(service_values, managed_values)
 
     # Service data overrides from clusters/
     customer_values, _ = get_service_data(

--- a/libsentrykube/service.py
+++ b/libsentrykube/service.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List
+from typing import List, Mapping, Any
 
 import click
 import yaml
@@ -70,14 +70,13 @@ def get_service_values(service_name: str, external: bool = False) -> dict:
     return values
 
 
-def get_service_value_overrides(
+def get_service_value_override_path(
     service_name: str,
     region_name: str,
-    cluster_name: str = "default",
     external: bool = False,
-) -> dict:
+) -> Path:
     """
-    For the given service, return the values specified in the corresponding _values.yaml.
+    For the given service, return the path to the override files.
 
     If "external=True" is specified, treat the service name as the full service path.
     """
@@ -91,15 +90,83 @@ def get_service_value_overrides(
     if region_name == "saas":
         region_name = "us"
 
+    return service_regions_path / region_name
+
+
+def get_service_value_overrides(
+    service_name: str,
+    region_name: str,
+    cluster_name: str = "default",
+    external: bool = False,
+) -> dict:
+    """
+    For the given service, return the values specified in the corresponding _values.yaml.
+
+    If "external=True" is specified, treat the service name as the full service path.
+    """
     try:
-        service_override_file: Path = (
-            service_regions_path / region_name / f"{cluster_name}.yaml"
+        service_override_file = (
+            get_service_value_override_path(service_name, region_name, external)
+            / f"{cluster_name}.yaml"
         )
+
         with open(service_override_file, "rb") as f:
             values = yaml.safe_load(f)
     except FileNotFoundError:
         values = {}
     return values
+
+
+def get_managed_service_value_overrides(
+    service_name: str,
+    region_name: str,
+    cluster_name: str = "default",
+    external: bool = False,
+) -> dict:
+    """
+    We have two override files. Conceptually there is no difference
+    but one is manually managed and the other is managed by automated
+    tools.
+
+    The manually managed one can have comments, most yaml parsers do
+    not preserve comments, so it is safer to keep a separate file.
+
+    The managed file is patched by tools like quickpatch. Though it can
+    also be updated by hand knowing that comments would not be preserved.
+
+    The managed file is applied last.
+    """
+    service_override_file = (
+        get_service_value_override_path(service_name, region_name, external)
+        / f"{cluster_name}.managed.yaml"
+    )
+
+    if service_override_file.exists() and service_override_file.is_file():
+        with open(service_override_file, "rb") as f:
+            return yaml.safe_load(f)
+
+    return {}
+
+
+def write_managed_values_overrides(
+    values: Mapping[str, Any],
+    service_name: str,
+    region_name: str,
+    cluster_name: str = "default",
+    external: bool = False,
+) -> None:
+    """
+    Some tools like `quickpatch` allow us to write the the managed file after
+    making changes.
+    This is the functions that updates the file.
+    """
+    service_override_file = (
+        get_service_value_override_path(service_name, region_name, external)
+        / f"{cluster_name}.managed.yaml"
+    )
+
+    with open(service_override_file, "w") as file:
+        yaml.dump(values, file)
 
 
 def get_service_data(

--- a/libsentrykube/service.py
+++ b/libsentrykube/service.py
@@ -117,7 +117,7 @@ def get_service_value_overrides(
     return values
 
 
-def get_managed_service_value_overrides(
+def get_tools_managed_service_value_overrides(
     service_name: str,
     region_name: str,
     cluster_name: str = "default",

--- a/libsentrykube/service.py
+++ b/libsentrykube/service.py
@@ -166,6 +166,15 @@ def write_managed_values_overrides(
     )
 
     with open(service_override_file, "w") as file:
+        file.write("# This file contains override value managed by tools\n")
+        file.write("# \n")
+        file.write("# It is discouraged to update it manually. Use the tool instead\n")
+        file.write("# unless you really have to.\n")
+        file.write("# Updating this manually is safe as long as:\n")
+        file.write("# - you do not add comments. They are going to be erased\n")
+        file.write("# - you do not turn it into a Jinja template. That breaks tools\n")
+        file.write("# - you keep the structure intact and only change literals\n")
+        file.write("\n")
         yaml.dump(values, file)
 
 

--- a/libsentrykube/tests/conftest.py
+++ b/libsentrykube/tests/conftest.py
@@ -1,5 +1,8 @@
 import os
-from typing import Iterator
+from typing import Iterator, Generator
+import tempfile
+from pathlib import Path
+from yaml import safe_dump
 
 import pytest
 from libsentrykube.utils import set_workspace_root_start
@@ -19,4 +22,106 @@ def set_workspaceroot() -> Iterator[None]:
     set_workspace_root_start((workspace_root() / "libsentrykube/tests").as_posix())
     os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(workspace_root() / "config.yaml")
     yield
+    set_workspace_root_start(start_workspace_root)
+
+
+CLUSTER_1 = {
+    "id": "cluster1",
+    "services": [
+        "k8s/services/my_service",
+        "k8s/services/another_service",
+    ],
+    "my_service": {"key1": "value1"},
+}
+
+CLUSTER_2 = {
+    "id": "cluster2",
+    "services": [
+        "k8s/services/my_service",
+    ],
+}
+
+CONFIGURATION = {
+    "sites": {
+        "test_site": {
+            "name": "us",
+            "region": "us-central1",
+            "zone": "b",
+            "network": "global/networks/sentry",
+            "subnetwork": "regions/us-central1/subnetworks/sentry-default",
+        }
+    },
+    "silo_regions": {
+        "customer1": {
+            "bastion": {
+                "spawner_endpoint": "FIXME",
+                "site": "test_site",
+            },
+            "k8s": {
+                "root": "k8s",
+                "cluster_def_root": "clusters",
+                "services_in_cluster_config": "True",
+                "materialized_manifests": "materialized_manifests",
+            },
+        },
+        "customer2": {
+            "bastion": {
+                "spawner_endpoint": "FIXME",
+                "site": "test_site",
+            },
+            "k8s": {
+                "root": "k8s",
+                "cluster_def_root": "clusters",
+                "services_in_cluster_config": "True",
+                "materialized_manifests": "materialized_manifests",
+            },
+        },
+    },
+}
+
+
+@pytest.fixture
+def config_structure() -> Generator[str, None, None]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        k8s = Path(temp_dir) / "k8s"
+
+        services = k8s / "services"
+        os.makedirs(services / "my_service")
+        my_service = services / "my_service"
+        with open(my_service / "deployment.yaml", "w") as f:
+            f.write("")
+        with open(my_service / "_values.yaml", "w") as f:
+            f.write(safe_dump({"key1": "value1"}))
+
+        os.makedirs(services / "my_service" / "region_overrides" / "customer1")
+
+        os.makedirs(services / "another_service")
+        another_service = services / "another_service"
+        with open(another_service / "deployment.yaml", "w") as f:
+            f.write("")
+
+        os.makedirs(k8s / "clusters")
+        clusters = k8s / "clusters"
+        with open(clusters / "cluster1.yaml", "w") as f:
+            f.write(safe_dump(CLUSTER_1))
+        with open(clusters / "cluster2.yaml", "w") as f:
+            f.write(safe_dump(CLUSTER_2))
+
+        os.makedirs(Path(temp_dir) / "cli_config")
+        with open(Path(temp_dir) / "cli_config/configuration.yaml", "w") as f:
+            f.write(safe_dump(CONFIGURATION))
+
+        yield temp_dir
+
+
+@pytest.fixture
+def initialized_config_structure(config_structure: str) -> Generator[str, None, None]:
+    directory = config_structure
+
+    start_workspace_root = workspace_root().as_posix()
+    set_workspace_root_start(directory)
+    os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
+        workspace_root() / "cli_config/configuration.yaml"
+    )
+    yield directory
     set_workspace_root_start(start_workspace_root)

--- a/libsentrykube/tests/k8s_root/clusters/saas/customer.yaml
+++ b/libsentrykube/tests/k8s_root/clusters/saas/customer.yaml
@@ -12,3 +12,6 @@ services:
 
 service2:
   key3: three
+
+service4:
+  key1: value4

--- a/libsentrykube/tests/k8s_root/services/service1/region_overrides/us/customer.managed.yaml
+++ b/libsentrykube/tests/k8s_root/services/service1/region_overrides/us/customer.managed.yaml
@@ -1,5 +1,5 @@
 key2:
-  subkey2_3:
-    - value2_3_1_managed_replaced
   subkey2_4:
     - value2_4_1_managed_replaced
+  subkey2_5:
+    - value2_5_1_managed_replaced

--- a/libsentrykube/tests/k8s_root/services/service1/region_overrides/us/customer.managed.yaml
+++ b/libsentrykube/tests/k8s_root/services/service1/region_overrides/us/customer.managed.yaml
@@ -1,0 +1,5 @@
+key2:
+  subkey2_3:
+    - value2_3_1_managed_replaced
+  subkey2_4:
+    - value2_4_1_managed_replaced

--- a/libsentrykube/tests/k8s_root/services/service1/region_overrides/us/customer.yaml
+++ b/libsentrykube/tests/k8s_root/services/service1/region_overrides/us/customer.yaml
@@ -1,3 +1,5 @@
 key2:
   subkey2_3:
     - value2_3_1_replaced
+  subkey2_4:
+    - value2_4_1_replaced

--- a/libsentrykube/tests/k8s_root/services/service4/_values.yaml
+++ b/libsentrykube/tests/k8s_root/services/service4/_values.yaml
@@ -1,0 +1,1 @@
+key1: value1

--- a/libsentrykube/tests/k8s_root/services/service4/region_overrides/us/customer.managed.yaml
+++ b/libsentrykube/tests/k8s_root/services/service4/region_overrides/us/customer.managed.yaml
@@ -1,0 +1,1 @@
+key1: value2

--- a/libsentrykube/tests/k8s_root/services/service4/region_overrides/us/customer.yaml
+++ b/libsentrykube/tests/k8s_root/services/service4/region_overrides/us/customer.yaml
@@ -1,0 +1,1 @@
+key1: value2

--- a/libsentrykube/tests/test_kube.py
+++ b/libsentrykube/tests/test_kube.py
@@ -1,18 +1,28 @@
+from libsentrykube.context import init_cluster_context
 from libsentrykube.kube import _consolidate_variables
 
 expected_consolidated_values = {
     "saas": {
         "customer": {
             "service1": {
-                "key1": "value1",
+                "key1": "value1",  # From the value file
                 "key2": {
-                    "subkey2_1": "value2_1",
-                    "subkey2_2": 2,
-                    "subkey2_3": ["value2_3_1_replaced"],
+                    "subkey2_1": "value2_1",  # From the value file
+                    "subkey2_2": 2,  # From the value file
+                    "subkey2_3": ["value2_3_1_replaced"],  # From the region override
+                    "subkey2_4": [
+                        "value2_4_1_managed_replaced"
+                    ],  # From the managed file
+                    "subkey2_5": [
+                        "value2_5_1_managed_replaced"
+                    ],  # From the managed file
                 },
             },
             "service2": {
-                "key3": "three",
+                "key3": "three",  # From the cluster file
+            },
+            "service4": {
+                "key1": "value4",  # Cluster file overrides everything
             },
         }
     }
@@ -22,7 +32,8 @@ expected_consolidated_values = {
 def test_consolidate_variables_not_external():
     region = "saas"
     cluster = "customer"
-    for service in ["service1", "service2"]:
+    init_cluster_context(region, cluster)
+    for service in ["service1", "service2", "service4"]:
         returned = _consolidate_variables(
             customer_name=region,
             service_name=service,

--- a/libsentrykube/tests/test_service.py
+++ b/libsentrykube/tests/test_service.py
@@ -4,7 +4,7 @@ from libsentrykube.service import (
     get_service_data,
     get_service_values,
     get_service_value_overrides,
-    get_managed_service_value_overrides,
+    get_tools_managed_service_value_overrides,
     get_service_value_override_path,
     get_service_path,
     write_managed_values_overrides,
@@ -118,7 +118,7 @@ def test_get_service_value_managed_overrides():
 
     init_cluster_context(region, cluster)
     for service in ["service1", "service2"]:
-        returned = get_managed_service_value_overrides(
+        returned = get_tools_managed_service_value_overrides(
             service_name=service,
             region_name=region,
             cluster_name=cluster,
@@ -165,7 +165,7 @@ def test_write_managed_file(config_structure) -> None:
     write_managed_values_overrides(
         {"key2": "value2"}, "my_service", "customer1", "cluster1"
     )
-    assert get_managed_service_value_overrides(
+    assert get_tools_managed_service_value_overrides(
         service_name="my_service",
         region_name="customer1",
         cluster_name="cluster1",

--- a/libsentrykube/tests/test_service.py
+++ b/libsentrykube/tests/test_service.py
@@ -3,6 +3,7 @@ from libsentrykube.service import (
     get_service_data,
     get_service_values,
     get_service_value_overrides,
+    get_managed_service_value_overrides,
 )
 
 
@@ -68,6 +69,25 @@ def test_get_service_value_overrides_present():
             external=False,
         )
         assert returned == expected_service_value_overrides[region][cluster][service]
+
+
+def test_get_service_value_managed_overrides_present():
+    region = "saas"
+    cluster = "customer"
+
+    init_cluster_context(region, cluster)
+    returned = get_managed_service_value_overrides(
+        service_name="service1",
+        region_name=region,
+        cluster_name=cluster,
+        external=False,
+    )
+    assert returned == {
+        "key2": {
+            "subkey2_3": ["value2_3_1_managed_replaced"],
+            "subkey2_4": ["value2_4_1_managed_replaced"],
+        }
+    }
 
 
 def test_get_service_value_overrides_missing():


### PR DESCRIPTION
The quickpatch tool was supposed to patch directly the region override files
for each service.

Sadly w ecould not find a viable yaml parser that would preserve comments.
We are likely going to build one eventually. Till then, though, this seems
the only option to allow any tool make changes to our value files.

We add a second override file: `cluster.managed.yaml`. This file can be
rewritten by tools, so you should not add comments. It can be updated by hand,
(though why?) as tools are patching the file rather than regenerating it.

The override happens right after the region override. 
