### PR TITLE
Wire up patches into sentry-kube quickpatch

### DIFF
--- a/libsentrykube/quickpatch.py
+++ b/libsentrykube/quickpatch.py
@@ -142,9 +142,6 @@ def apply_patch(
     resource_data = get_tools_managed_service_value_overrides(
         service, region, cluster_name=cluster
     )
-    if resource_data == {}:
-        raise FileNotFoundError(
-            f"Resource value file not found for service {service} in region {region}"
-        )
+
     resource_data = json_patch.apply(resource_data)
     write_managed_values_overrides(resource_data, service, region, cluster_name=cluster)

--- a/libsentrykube/tests/test_data/quickpatches/test-patch-no-file.yaml
+++ b/libsentrykube/tests/test_data/quickpatches/test-patch-no-file.yaml
@@ -1,0 +1,31 @@
+# Each patch file defines a patch for a single resource
+name: Scale Example
+schema:
+  type: object
+  properties:
+    replicas1:
+      type: integer
+      minimum: 1
+      maximum: 10
+    replicas2:
+      type: integer
+      minimum: 1
+      maximum: 10
+  required:
+    - replicas1
+    - replicas2
+  additionalProperties: false
+mappings:
+  # Only the keys here are valid resources which patches can be applied to
+  test-consumer-prod: consumer
+patches:
+  # Key-Values should follow jsonpatch format
+  - op: add
+    path: /consumers
+    value: {}
+  - op: add
+    path: /consumers/<resource>
+    value: {}
+  - op: add
+    path: /consumers/<resource>/replicas
+    value: <replicas1>

--- a/libsentrykube/tests/test_quickpatch.py
+++ b/libsentrykube/tests/test_quickpatch.py
@@ -97,29 +97,34 @@ def test_missing_patch_file1():
 
 
 def test_missing_value_file(reset_configs):
-    with pytest.raises(
-        FileNotFoundError,
-        match=f"Resource value file not found for service {SERVICE} in region {REGION}",
-    ):
-        os.remove(
-            Path(reset_configs)
-            / "k8s"
-            / "services"
-            / SERVICE
-            / "region_overrides"
-            / REGION
-            / "default.managed.yaml"
-        )
-        apply_patch(
-            SERVICE,
-            REGION,
-            TEST_RESOURCE,
-            TEST_PATCH,
-            {
-                "replicas1": TEST_NUM_REPLICAS,
-                "replicas2": TEST_NUM_REPLICAS,
+    os.remove(
+        Path(reset_configs)
+        / "k8s"
+        / "services"
+        / SERVICE
+        / "region_overrides"
+        / REGION
+        / "default.managed.yaml"
+    )
+    apply_patch(
+        SERVICE,
+        REGION,
+        TEST_RESOURCE,
+        "test-patch-no-file",
+        {
+            "replicas1": TEST_NUM_REPLICAS,
+            "replicas2": TEST_NUM_REPLICAS,
+        },
+    )
+    expected = {
+        "consumers": {
+            "consumer": {
+                "replicas": TEST_NUM_REPLICAS,
             },
-        )
+        },
+    }
+    actual = get_tools_managed_service_value_overrides(SERVICE, REGION, CLUSTER, False)
+    assert expected == actual
 
 
 def test_missing_patches():
@@ -254,20 +259,6 @@ def test_invalid_schema(patch):
             REGION,
             TEST_RESOURCE,
             patch,
-            {
-                "replicas1": TEST_NUM_REPLICAS,
-                "replicas2": TEST_NUM_REPLICAS,
-            },
-        )
-
-
-def test_missing_resource_file():
-    with pytest.raises(FileNotFoundError, match="Resource value file not found"):
-        apply_patch(
-            SERVICE,
-            "invalid-region",  # Non-existent region
-            TEST_RESOURCE,
-            TEST_PATCH,
             {
                 "replicas1": TEST_NUM_REPLICAS,
                 "replicas2": TEST_NUM_REPLICAS,

--- a/sentry_kube/cli/__init__.py
+++ b/sentry_kube/cli/__init__.py
@@ -182,7 +182,12 @@ Customers include:
 
         set_service_paths(cluster.services)
 
-        if ctx.invoked_subcommand in ("rendervalues", "render", "lint", "validate"):
+        if ctx.invoked_subcommand in (
+            "rendervalues",
+            "render",
+            "lint",
+            "validate",
+        ):
             if not customer:
                 die(
                     f"Please pass in a customer to {ctx.invoked_subcommand} "


### PR DESCRIPTION
Wire up what we built.

Specifically:
1. create three subcommands (they are arguments, not subcommands). One for render, diff and apply 
2. Implement diff and render. Tested against s4s and it works 
3. Added a rudimentary parsing of arguments from the command line
3. Fixed the quickpatch module in case the managed file is not there. Now it gets created 
4. Tested against a test patch in snuba s4s.

What is missing (separate PRs)
- validation of the arguments according to the types defined in the jsonschema in the patch
- figure out how to express a patch that is able to either update fields or create paths 
- implement apply 
- add the git part
