### PR TITLE
Use own jsonpatch implementation

### DIFF
--- a/libsentrykube/quickpatch.py
+++ b/libsentrykube/quickpatch.py
@@ -98,7 +98,7 @@ class PatchOperation(TypedDict):
 
 def patch_json(
     patches: List[PatchOperation], resource: MutableMapping[str, Any]
-) -> MutableMapping:
+) -> MutableMapping[str, Any]:
     """
     This function applies the patch to the resource json object
     in-place.

--- a/libsentrykube/quickpatch.py
+++ b/libsentrykube/quickpatch.py
@@ -136,6 +136,8 @@ def patch_json(
     """
     for patch in patches:
         data = resource
+        if not isinstance(data, dict):
+            raise ValueError("resource must be a dict")
         path = patch.get("path", None)
         value = patch.get("value")
         if path is not None:

--- a/libsentrykube/quickpatch.py
+++ b/libsentrykube/quickpatch.py
@@ -127,6 +127,12 @@ def patch_json(
     - The value of the final key in the path will be replaced with the value
     specified in the patch. So, to avoid overwriting existing values, the
     path should contain the full path to the key to be replaced.
+
+    Example Patches:
+    [{"path": "a/b/c", "value": 1}] + {"a": {"b": {"c": 0}}} -> {"a": {"b": {"c": 1}}}
+    [{"path": "a/b/c", "value": {"d": 1}}] + {"a": {"b": {"c": 0}}} -> {"a": {"b": {"c": {"d": 1}}}}
+    [{"path": "a/c", "value": 1}] + {"a": {"b": 0}} -> {"a": {"b": 0, "c": 1}}
+    [{"path": "a/b", "value": {"d": 1}}] + {"a": {"b": {"f": 2}}} -> {"a": {"b": {"d": 1}}}
     """
     for patch in patches:
         data = resource

--- a/libsentrykube/quickpatch.py
+++ b/libsentrykube/quickpatch.py
@@ -129,10 +129,10 @@ def patch_json(
     path should contain the full path to the key to be replaced.
 
     Example Patches:
-    [{"path": "a/b/c", "value": 1}] + {"a": {"b": {"c": 0}}} -> {"a": {"b": {"c": 1}}}
-    [{"path": "a/b/c", "value": {"d": 1}}] + {"a": {"b": {"c": 0}}} -> {"a": {"b": {"c": {"d": 1}}}}
-    [{"path": "a/c", "value": 1}] + {"a": {"b": 0}} -> {"a": {"b": 0, "c": 1}}
-    [{"path": "a/b", "value": {"d": 1}}] + {"a": {"b": {"f": 2}}} -> {"a": {"b": {"d": 1}}}
+    [{"path": "a/b/c", "value": 1}] + {"a": {"b": {"c": 0}}} -> {"a": {"b": {"c": 1}}} # Overwrite existing value
+    [{"path": "a/b/c", "value": {"d": 1}}] + {"a": {"b": {"c": 0}}} -> {"a": {"b": {"c": {"d": 1}}}} # Overwrite existing value with a dict
+    [{"path": "a/c", "value": 1}] + {"a": {"b": 0}} -> {"a": {"b": 0, "c": 1}} # Create new key-value
+    [{"path": "a/b", "value": {"d": 1}}] + {"a": {"b": {"f": 2}}} -> {"a": {"b": {"d": 1}}} # Overwrite existing dict with a dict
     """
     for patch in patches:
         data = resource

--- a/libsentrykube/quickpatch.py
+++ b/libsentrykube/quickpatch.py
@@ -191,7 +191,7 @@ def apply_patch(
     variables["resource"] = resource_mappings[resource]
     patch_data_str = patch_file.read_text()
     for arg, arg_value in variables.items():
-        pattern = r"<\s*" + re.escape(arg) + r"\s*>"
+        pattern = r"(?<!\\)<\s*" + re.escape(arg) + r"\s*>"
         patch_data_str = re.sub(pattern, str(arg_value), patch_data_str)
 
     # Load the patch

--- a/libsentrykube/quickpatch.py
+++ b/libsentrykube/quickpatch.py
@@ -204,5 +204,5 @@ def apply_patch(
     )
     if resource_data is None:  # If the .yaml file is empty
         resource_data = {}
-    patched_data = patch_json(patches, resource_data)
-    write_managed_values_overrides(patched_data, service, region, cluster_name=cluster)
+    modified_data = patch_json(patches, resource_data)
+    write_managed_values_overrides(modified_data, service, region, cluster_name=cluster)

--- a/libsentrykube/quickpatch.py
+++ b/libsentrykube/quickpatch.py
@@ -93,12 +93,12 @@ def get_arguments(service: str, patch: str) -> Sequence[str]:
 
 class PatchOperation(TypedDict):
     path: str
-    value: Union[str, int, float]
+    value: Union[str, int, float, bool]
 
 
 def patch_json(
-    patches: List[PatchOperation], resource: dict[str, Any]
-) -> dict[str, Any]:
+    patches: List[PatchOperation], resource: MutableMapping[str, Any]
+) -> MutableMapping:
     """
     This function applies the patch to the resource json object
     in-place.
@@ -204,5 +204,5 @@ def apply_patch(
     )
     if resource_data is None:  # If the .yaml file is empty
         resource_data = {}
-    resource_data = patch_json(patches, resource_data)
-    write_managed_values_overrides(resource_data, service, region, cluster_name=cluster)
+    patched_data = patch_json(patches, resource_data)
+    write_managed_values_overrides(patched_data, service, region, cluster_name=cluster)

--- a/libsentrykube/quickpatch.py
+++ b/libsentrykube/quickpatch.py
@@ -146,6 +146,10 @@ def patch_json(
             for path in paths[:-1]:
                 if path not in data:
                     data[path] = {}
+                elif not isinstance(data[path], dict):
+                    raise ValueError(
+                        f"Cannot traverse path '{path}' as it points to a non-dictionary value"
+                    )
                 data = data[path]
             data[paths[-1]] = value
         else:

--- a/libsentrykube/tests/test_data/quickpatches/invalid-schema1.yaml
+++ b/libsentrykube/tests/test_data/quickpatches/invalid-schema1.yaml
@@ -19,9 +19,7 @@ mappings:
   test-consumer-prod: consumer
 patches:
   # Key-Values should follow jsonpatch format
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas1>
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas2>

--- a/libsentrykube/tests/test_data/quickpatches/invalid-schema2.yaml
+++ b/libsentrykube/tests/test_data/quickpatches/invalid-schema2.yaml
@@ -20,9 +20,7 @@ mappings:
   test-consumer-prod: consumer
 patches:
   # Key-Values should follow jsonpatch format
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas1>
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas2>

--- a/libsentrykube/tests/test_data/quickpatches/invalid-schema3.yaml
+++ b/libsentrykube/tests/test_data/quickpatches/invalid-schema3.yaml
@@ -19,9 +19,7 @@ mappings:
   test-consumer-prod: consumer
 patches:
   # Key-Values should follow jsonpatch format
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas1>
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas2>

--- a/libsentrykube/tests/test_data/quickpatches/test-patch-missing-mappings.yaml
+++ b/libsentrykube/tests/test_data/quickpatches/test-patch-missing-mappings.yaml
@@ -17,9 +17,7 @@ schema:
   additionalProperties: false
 patches:
   # Key-Values should follow jsonpatch format
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas1>
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas2>

--- a/libsentrykube/tests/test_data/quickpatches/test-patch-missing-schema.yaml
+++ b/libsentrykube/tests/test_data/quickpatches/test-patch-missing-schema.yaml
@@ -5,9 +5,7 @@ mappings:
   test-consumer-prod: consumer
 patches:
   # Key-Values should follow jsonpatch format
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas1>
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas2>

--- a/libsentrykube/tests/test_data/quickpatches/test-patch-override.yaml
+++ b/libsentrykube/tests/test_data/quickpatches/test-patch-override.yaml
@@ -20,9 +20,7 @@ mappings:
   test-consumer-prod: consumer
 patches:
   # Key-Values should follow jsonpatch format
-  - op: replace
-    path: /consumers
+  - path: /consumers
     value: { "<resource>": { "replicas": <replicas1> } }
-  - op: replace
-    path: /consumers
+  - path: /consumers
     value: { "<resource>": { "replicas": <replicas2> } }

--- a/libsentrykube/tests/test_data/quickpatches/test-patch-override.yaml
+++ b/libsentrykube/tests/test_data/quickpatches/test-patch-override.yaml
@@ -1,0 +1,28 @@
+# Each patch file defines a patch for a single resource
+name: Scale Example
+schema:
+  type: object
+  properties:
+    replicas1:
+      type: integer
+      minimum: 1
+      maximum: 10
+    replicas2:
+      type: integer
+      minimum: 1
+      maximum: 10
+  required:
+    - replicas1
+    - replicas2
+  additionalProperties: false
+mappings:
+  # Only the keys here are valid resources which patches can be applied to
+  test-consumer-prod: consumer
+patches:
+  # Key-Values should follow jsonpatch format
+  - op: replace
+    path: /consumers
+    value: { "<resource>": { "replicas": <replicas1> } }
+  - op: replace
+    path: /consumers
+    value: { "<resource>": { "replicas": <replicas2> } }

--- a/libsentrykube/tests/test_data/quickpatches/test-patch.yaml
+++ b/libsentrykube/tests/test_data/quickpatches/test-patch.yaml
@@ -20,9 +20,7 @@ mappings:
   test-consumer-prod: consumer
 patches:
   # Key-Values should follow jsonpatch format
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas1>
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas2>

--- a/libsentrykube/tests/test_data/quickpatches/test-patch2.yaml
+++ b/libsentrykube/tests/test_data/quickpatches/test-patch2.yaml
@@ -20,9 +20,7 @@ mappings:
   test-consumer-prod: consumer
 patches:
   # Key-Values should follow jsonpatch format
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas-1>
-  - op: replace
-    path: /consumers/<resource>/replicas
+  - path: /consumers/<resource>/replicas
     value: <replicas_2>

--- a/libsentrykube/tests/test_data/values/default2.managed.yaml
+++ b/libsentrykube/tests/test_data/values/default2.managed.yaml
@@ -1,0 +1,3 @@
+consumers:
+  existing-consumer:
+    replicas: 4

--- a/libsentrykube/tests/test_data/values/empty.managed.yaml
+++ b/libsentrykube/tests/test_data/values/empty.managed.yaml
@@ -1,0 +1,3 @@
+consumers:
+  consumer:
+    replicas: 4

--- a/libsentrykube/tests/test_quickpatch.py
+++ b/libsentrykube/tests/test_quickpatch.py
@@ -196,6 +196,21 @@ def test_invalid_resource():
         ),  # Test with missing .managed.yaml file (it should auto-generate)
         pytest.param(
             "test-patch",
+            "empty",
+            {
+                "consumers": {
+                    "consumer": {
+                        "replicas": TEST_NUM_REPLICAS,
+                    },
+                },
+            },
+            {
+                "replicas1": TEST_NUM_REPLICAS,
+                "replicas2": TEST_NUM_REPLICAS,
+            },
+        ),  # Test with empty .managed.yaml file (it should auto-generate)
+        pytest.param(
+            "test-patch",
             "default2",
             {
                 "consumers": {

--- a/libsentrykube/tests/test_quickpatch.py
+++ b/libsentrykube/tests/test_quickpatch.py
@@ -474,3 +474,16 @@ def test_patch_json_invalid_path():
             ],
             {},
         )  # invalid path value
+    with pytest.raises(
+        ValueError,
+        match="Cannot traverse path 'a' as it points to a non-dictionary value",
+    ):
+        patch_json(
+            [
+                {
+                    "path": "a/b",
+                    "value": TEST_NUM_REPLICAS,
+                }
+            ],
+            {"a": []},
+        )  # invalid path value

--- a/libsentrykube/tests/test_quickpatch.py
+++ b/libsentrykube/tests/test_quickpatch.py
@@ -163,7 +163,8 @@ def test_invalid_resource():
                 "replicas1": TEST_NUM_REPLICAS,
                 "replicas2": TEST_NUM_REPLICAS,
             },
-        ),  # Normal patch test
+            id="Normal patch test",
+        ),
         pytest.param(
             "test-patch2",
             CLUSTER,
@@ -178,7 +179,8 @@ def test_invalid_resource():
                 "replicas-1": TEST_NUM_REPLICAS,
                 "replicas_2": TEST_NUM_REPLICAS,
             },
-        ),  # Normal patch test
+            id="Normal patch test2",
+        ),
         pytest.param(
             "test-patch",
             "missing-file",
@@ -193,7 +195,8 @@ def test_invalid_resource():
                 "replicas1": TEST_NUM_REPLICAS,
                 "replicas2": TEST_NUM_REPLICAS,
             },
-        ),  # Test with missing .managed.yaml file (it should auto-generate)
+            id="Test with missing .managed.yaml file (it should auto-generate)",
+        ),
         pytest.param(
             "test-patch",
             "empty",
@@ -208,7 +211,8 @@ def test_invalid_resource():
                 "replicas1": TEST_NUM_REPLICAS,
                 "replicas2": TEST_NUM_REPLICAS,
             },
-        ),  # Test with empty .managed.yaml file (it should auto-generate)
+            id="Test with empty .managed.yaml file (it should auto-generate)",
+        ),
         pytest.param(
             "test-patch",
             "default2",
@@ -226,7 +230,8 @@ def test_invalid_resource():
                 "replicas1": TEST_NUM_REPLICAS,
                 "replicas2": TEST_NUM_REPLICAS,
             },
-        ),  # Test with missing resources in yaml file (it should auto-generate)
+            id="Test with missing resources in yaml file (it should auto-generate)",
+        ),
         pytest.param(
             "test-patch-override",
             "default2",
@@ -241,8 +246,8 @@ def test_invalid_resource():
                 "replicas1": TEST_NUM_REPLICAS,
                 "replicas2": TEST_NUM_REPLICAS,
             },
-        ),  # Test override of existing resource.
-        # Expects to override all resources at the same path level with the value
+            id="Test override of existing resource.",
+        ),  # Expects to override all resources at the same path level with the value
     ],
 )
 def test_correct_patch(patch, cluster, expected, args):
@@ -376,7 +381,8 @@ def test_validations(expected_message, arguments):
             ],
             {},
             {"a": {"b": {"c": TEST_NUM_REPLICAS}}},
-        ),  # Whole path is not present, should create
+            id="Whole path is not present, should create",
+        ),
         pytest.param(
             [
                 {
@@ -386,7 +392,8 @@ def test_validations(expected_message, arguments):
             ],
             {"a": {}},
             {"a": {"b": {"c": TEST_NUM_REPLICAS}}},
-        ),  # Part of path is not present, should create
+            id="Part of path is not present, should create",
+        ),
         pytest.param(
             [
                 {
@@ -396,7 +403,8 @@ def test_validations(expected_message, arguments):
             ],
             {"a": {"b": {"c": 0}}},
             {"a": {"b": {"c": TEST_NUM_REPLICAS}}},
-        ),  # Update existing value
+            id="Update existing value",
+        ),
         pytest.param(
             [
                 {
@@ -406,7 +414,8 @@ def test_validations(expected_message, arguments):
             ],
             {"a": {"b": {"c": 0}}},
             {"a": {"b": {"c": {"d": TEST_NUM_REPLICAS}}}},
-        ),  # Apply a dict, should override existing value
+            id="Apply a dict, should override existing value",
+        ),
         pytest.param(
             [
                 {
@@ -416,7 +425,8 @@ def test_validations(expected_message, arguments):
             ],
             {"a": {"b": {"c": 0}}},
             {"a": {"b": {"c": 0, "d": {"e": TEST_NUM_REPLICAS}}}},
-        ),  # Apply a dict with an existing dict
+            id="Apply a dict with an existing dict",
+        ),
         pytest.param(
             [
                 {
@@ -426,7 +436,8 @@ def test_validations(expected_message, arguments):
             ],
             {},
             {"a": {"b": {"c": TEST_NUM_REPLICAS}}},
-        ),  # Weird path
+            id="Weird path",
+        ),
         pytest.param(
             [
                 {
@@ -436,7 +447,8 @@ def test_validations(expected_message, arguments):
             ],
             {"a": {"b": {"c": 0}}},
             {"a": {"b": {"c": {"d": TEST_NUM_REPLICAS}}}},
-        ),  # Should replace existing value
+            id="Should replace existing value",
+        ),
     ],
 )
 def test_patch_json(patch, resource, expected):

--- a/libsentrykube/tests/test_quickpatch.py
+++ b/libsentrykube/tests/test_quickpatch.py
@@ -486,4 +486,17 @@ def test_patch_json_invalid_path():
                 }
             ],
             {"a": []},
-        )  # invalid path value
+        )  # not a dict
+    with pytest.raises(
+        ValueError,
+        match="resource must be a dict",
+    ):
+        patch_json(
+            [
+                {
+                    "path": "a",
+                    "value": TEST_NUM_REPLICAS,
+                }
+            ],
+            [],
+        )  # not a dict

--- a/libsentrykube/tests/test_quickpatch.py
+++ b/libsentrykube/tests/test_quickpatch.py
@@ -406,7 +406,7 @@ def test_validations(expected_message, arguments):
             ],
             {"a": {"b": {"c": 0}}},
             {"a": {"b": {"c": {"d": TEST_NUM_REPLICAS}}}},
-        ),  # Apply a dict
+        ),  # Apply a dict, should override existing value
         pytest.param(
             [
                 {
@@ -427,6 +427,16 @@ def test_validations(expected_message, arguments):
             {},
             {"a": {"b": {"c": TEST_NUM_REPLICAS}}},
         ),  # Weird path
+        pytest.param(
+            [
+                {
+                    "path": "a/b/c",
+                    "value": {"d": TEST_NUM_REPLICAS},
+                }
+            ],
+            {"a": {"b": {"c": 0}}},
+            {"a": {"b": {"c": {"d": TEST_NUM_REPLICAS}}}},
+        ),  # Should replace existing value
     ],
 )
 def test_patch_json(patch, resource, expected):


### PR DESCRIPTION
This PR deprecates the use of jsonpatch in quickpatch and instead uses our own patcher:

The patcher interprets the paths defined in the .managed.yaml file according to a few rules:
1. Paths must be separated by `/`
2. Paths must refer to nested json objs in the corresponding values file that is being patched
3. If the json obj in the `.managed.yaml` file does not exist, the patcher will auto-generate all of the relevant objs as needed & defined by the patch
4. If the values file does not exist, the patcher will also auto-generate the `.managed.yaml` file
5. Any values that are defined in the patch will be set at the path location. Aka, the patcher may override existing objs at the defined path. To avoid this issue, specify the full length of the path down to the lowest-nested level, with the value containing a single scalar or string. See the added `test-patch-override.yaml` file for example of this override happening.