### PR TITLE
chore(service-registry): Add python package import solution

### DIFF
--- a/config_builder/materialize_all.py
+++ b/config_builder/materialize_all.py
@@ -76,6 +76,15 @@ def main(argv: Sequence[str] | None = None) -> None:
             The root directory of the shared configs.
         """,
     )
+    parser.add_argument(
+        "--ext-package",
+        type=str,
+        action="store",
+        default="",
+        help="""
+            Name of external package to add to jsonnet import paths.
+        """,
+    )
 
     args = parser.parse_args(argv)
     if args.combine_sources:
@@ -103,7 +112,9 @@ def main(argv: Sequence[str] | None = None) -> None:
     materialized_root = Path(args.output_directory) if args.output_directory else None
     for file in iterate_jsonnet_configs(Path(args.root_dir), args.exclude_dirs):
         try:
-            materialize_file(Path(args.root_dir), file, materialized_root)
+            materialize_file(
+                Path(args.root_dir), file, materialized_root, args.ext_package
+            )
         except JsonnetException as e:
             print(f"{RED}Jsonnet Error occurred while materializing {file}{RESET}")
             print(f"{e.__cause__}")

--- a/config_builder/materialize_all.py
+++ b/config_builder/materialize_all.py
@@ -77,10 +77,10 @@ def main(argv: Sequence[str] | None = None) -> None:
         """,
     )
     parser.add_argument(
-        "--ext-package",
-        type=str,
-        action="store",
-        default="",
+        "-p",
+        "--ext-packages",
+        action="append",
+        default=[],
         help="""
             Name of external package to add to jsonnet import paths.
         """,
@@ -113,7 +113,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     for file in iterate_jsonnet_configs(Path(args.root_dir), args.exclude_dirs):
         try:
             materialize_file(
-                Path(args.root_dir), file, materialized_root, args.ext_package
+                Path(args.root_dir), file, materialized_root, args.ext_packages
             )
         except JsonnetException as e:
             print(f"{RED}Jsonnet Error occurred while materializing {file}{RESET}")

--- a/config_builder/materializer.py
+++ b/config_builder/materializer.py
@@ -35,7 +35,7 @@ def materialize_file(
     root_dir: Path,
     jsonnet_file: Path,
     materialized_root: Path | None,
-    ext_packages: list = [],
+    ext_packages: list[str] = [],
 ) -> None:
     """
     Materialize a single jsonnet file

--- a/config_builder/materializer.py
+++ b/config_builder/materializer.py
@@ -49,6 +49,12 @@ def materialize_file(
     materialized_path = root_dir / materialized_root / relative_path
     os.makedirs(materialized_path.parent, exist_ok=True)
 
+    for ext_package in ext_packages:
+        try:
+            importlib.import_module(ext_package)
+        except ImportError:
+            raise ModuleNotFoundError(f"Package '{ext_package}' not found")
+
     def _import_callback(module: Path):
         if module.is_file():
             content = module.read_text()

--- a/config_builder/materializer.py
+++ b/config_builder/materializer.py
@@ -35,7 +35,7 @@ def materialize_file(
     root_dir: Path,
     jsonnet_file: Path,
     materialized_root: Path | None,
-    ext_package: str = "",
+    ext_packages: list = [],
 ) -> None:
     """
     Materialize a single jsonnet file
@@ -49,12 +49,17 @@ def materialize_file(
     materialized_path = root_dir / materialized_root / relative_path
     os.makedirs(materialized_path.parent, exist_ok=True)
 
-    if ext_package != "":
-        imported_module = importlib.import_module(ext_package)
-        if not hasattr(imported_module, "__file__") or imported_module.__file__ is None:
-            raise ValueError(f"Cannot determine path for module {ext_package}")
-        ext_package_path = Path(imported_module.__file__).parent.resolve()
-        import_paths = [ext_package_path]
+    if len(ext_packages) > 0:
+        import_paths = []
+        for ext_package in ext_packages:
+            imported_module = importlib.import_module(ext_package)
+            if (
+                not hasattr(imported_module, "__file__")
+                or imported_module.__file__ is None
+            ):
+                raise ValueError(f"Cannot determine path for module {ext_package}")
+            ext_package_path = Path(imported_module.__file__).parent.resolve()
+            import_paths.append(ext_package_path)
     else:
         import_paths = []
 

--- a/config_builder/materializer.py
+++ b/config_builder/materializer.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import site
 from typing import Generator
 
 import yaml
@@ -45,8 +46,17 @@ def materialize_file(
     materialized_path = root_dir / materialized_root / relative_path
     os.makedirs(materialized_path.parent, exist_ok=True)
 
+    def import_callback(base_dirs, rel_path):
+        # Add the site-packages path to the search path
+        search_paths = site.getsitepackages() + base_dirs
+        return jsonnet.JsonnetImportCallback(search_paths)
+
     try:
-        content = jsonnet(jsonnet_file.name, base_dir=jsonnet_file.parent.absolute())
+        content = jsonnet(
+            jsonnet_file.name,
+            base_dir=jsonnet_file.parent.absolute(),
+            import_callback=import_callback,
+        )
     except RuntimeError as e:
         raise JsonnetException() from e
 

--- a/config_builder/materializer.py
+++ b/config_builder/materializer.py
@@ -49,21 +49,15 @@ def materialize_file(
     materialized_path = root_dir / materialized_root / relative_path
     os.makedirs(materialized_path.parent, exist_ok=True)
 
-    if len(ext_packages) > 0:
-        import_paths = []
-        for ext_package in ext_packages:
-            imported_module = importlib.import_module(ext_package)
-            if (
-                not hasattr(imported_module, "__file__")
-                or imported_module.__file__ is None
-            ):
-                raise ValueError(f"Cannot determine path for module {ext_package}")
-            ext_package_path = Path(
-                imported_module.__file__
-            ).parent.parent.resolve()  # The directory where all pkgs are stored
-            import_paths.append(ext_package_path)
-    else:
-        import_paths = []
+    import_paths = []
+    for ext_package in ext_packages:
+        imported_module = importlib.import_module(ext_package)
+        if not hasattr(imported_module, "__file__") or imported_module.__file__ is None:
+            raise ValueError(f"Cannot determine path for module {ext_package}")
+        ext_package_path = Path(
+            imported_module.__file__
+        ).parent.parent.resolve()  # The directory where all pkgs are stored
+        import_paths.append(ext_package_path)
 
     try:
         content = jsonnet(

--- a/config_builder/materializer.py
+++ b/config_builder/materializer.py
@@ -58,7 +58,9 @@ def materialize_file(
                 or imported_module.__file__ is None
             ):
                 raise ValueError(f"Cannot determine path for module {ext_package}")
-            ext_package_path = Path(imported_module.__file__).parent.resolve()
+            ext_package_path = Path(
+                imported_module.__file__
+            ).parent.parent.resolve()  # The directory where all pkgs are stored
             import_paths.append(ext_package_path)
     else:
         import_paths = []

--- a/config_builder/materializer.py
+++ b/config_builder/materializer.py
@@ -2,7 +2,7 @@ import importlib
 import json
 import os
 from pathlib import Path
-from typing import Generator
+from typing import Generator, Union
 
 import yaml
 from sentry_jsonnet import jsonnet
@@ -55,12 +55,13 @@ def materialize_file(
         except ImportError:
             raise ModuleNotFoundError(f"Package '{ext_package}' not found")
 
-    def _import_callback(module: Path):
+    def _import_callback(module: Path) -> Union[str, bytes, None]:
         if module.is_file():
             content = module.read_text()
         elif module.exists():
             raise RuntimeError("Attempted to import a directory")
         else:  # cache the import-path miss
+            content = None
             module = module.resolve()
             rel_path = str(module).strip("/").split("/")
             ext_package = rel_path[0]

--- a/config_builder/test_materializer.py
+++ b/config_builder/test_materializer.py
@@ -3,7 +3,7 @@ import yaml
 import os
 import tempfile
 from pathlib import Path
-from typing import Generator
+from typing import Generator, List
 
 import pytest
 
@@ -107,3 +107,82 @@ def test_materialize_file(
                 json.loads(content)
         else:
             assert json.loads(content) == DICT_RESULT
+
+
+@pytest.mark.parametrize(
+    "materialized_root, expected_path, is_yaml, ext_packages",
+    [
+        pytest.param(
+            Path("some_subdir/_materialized_configs/"),
+            Path("some_subdir/_materialized_configs/feature1/combined/file1.json"),
+            False,
+            ["yaml"],
+            id="Put the materialized file in an arbitrary directory",
+        ),
+        pytest.param(
+            None,
+            Path("feature1/combined/file1.json"),
+            False,
+            ["os"],
+            id="Put the materialized file in an arbitrary directory",
+        ),
+        pytest.param(
+            None,
+            Path("feature1/combined/file3.yaml"),
+            True,
+            [],
+            id="Yaml file",
+        ),
+    ],
+)
+def test_materialize_file_ext_pkgs(
+    config_struct: str,
+    materialized_root: Path | None,
+    expected_path: Path,
+    is_yaml: bool,
+    ext_packages: List[str],
+) -> None:
+    jsonnet_file_path = (
+        f"{expected_path}.jsonnet" if is_yaml else "feature1/combined/file1.jsonnet"
+    )
+
+    materialize_file(
+        Path(config_struct),
+        Path(config_struct) / jsonnet_file_path,
+        materialized_root,
+        ext_packages=ext_packages,
+    )
+
+    expected_file = Path(config_struct) / expected_path
+    assert expected_file.exists()
+    with open(expected_file) as f:
+        content = f.read()
+        if is_yaml:
+            assert yaml.safe_load(content) == DICT_RESULT
+            with pytest.raises(json.decoder.JSONDecodeError):
+                json.loads(content)
+        else:
+            assert json.loads(content) == DICT_RESULT
+
+
+def test_materialize_file_missing_ext_pkgs(
+    config_struct: str,
+) -> None:
+    expected_path = Path("feature1/combined/file3.yaml")
+    jsonnet_file_path = f"{expected_path}.jsonnet"
+
+    with pytest.raises(ModuleNotFoundError):
+        materialize_file(
+            Path(config_struct),
+            Path(config_struct) / jsonnet_file_path,
+            None,
+            ext_packages=["definitely-missing-pkg-12345"],
+        )
+
+        expected_file = Path(config_struct) / expected_path
+        assert expected_file.exists()
+        with open(expected_file) as f:
+            content = f.read()
+            assert yaml.safe_load(content) == DICT_RESULT
+            with pytest.raises(json.decoder.JSONDecodeError):
+                json.loads(content)


### PR DESCRIPTION
This PR adds support for additional import paths (specifically, python packages) during jsonnet materialization. 

This can be used via the `--ext-package=python_package_name` cli argument