### PR TITLE
Add the gcloud CLI to the devenev setup

### DIFF
--- a/devenv/config.ini
+++ b/devenv/config.ini
@@ -16,3 +16,16 @@ linux_x86_64 = https://github.com/indygreg/python-build-standalone/releases/down
 linux_x86_64_sha256 = ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8
 linux_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6+20231002-aarch64-unknown-linux-gnu-install_only.tar.gz
 linux_arm64_sha256 = 3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec
+
+[gcloud]
+# used for autoupdate
+version = 490.0.0
+# custom python version not supported yet, it just uses
+# devenv's internal python 3.11
+# python = 3.11.6
+darwin_x86_64 = https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-490.0.0-darwin-x86_64.tar.gz
+darwin_x86_64_sha256 = fa396909acc763cf831dd5d89e778999debf37ceadccb3c1bdec606e59ba2694
+darwin_arm64 = https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-490.0.0-darwin-arm.tar.gz
+darwin_arm64_sha256 = a3a098a5f067b561e003c37284a9b164f28f37fd0d6371bb55e326679f48641c
+linux_x86_64 = https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-490.0.0-linux-x86_64.tar.gz
+linux_x86_64_sha256 = 40ce41958236f76d9cb08f377ccb9fd6502d2df4da14b36d9214bcb620e2b020

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
-from devenv.lib import config, venv
+from devenv.lib import venv, gcloud, config
+from devenv.constants import SYSTEM_MACHINE
 
 
 def main(context: dict[str, str]) -> int:
     repo = context["repo"]
     reporoot = context["reporoot"]
+
+    cfg = config.get_repo(reporoot)
+    gcloud.install(
+        cfg["gcloud"]["version"],
+        cfg["gcloud"][SYSTEM_MACHINE],
+        cfg["gcloud"][f"{SYSTEM_MACHINE}_sha256"],
+        reporoot,
+    )
 
     venv_dir, python_version, requirements, editable_paths, bins = venv.get(
         reporoot, repo


### PR DESCRIPTION
Some of the sentry-kube functionality need `gcloud` to be installed.
The devenv for sentry-infra-tools did not install it.  
