### PR TITLE
feat(sentrykube): introduce additional possibilities to override config

### DIFF
--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -249,9 +249,6 @@ def render_templates(
 
     return "\n---\n".join(rendered_templates)
 
-def materialize1(customer_name: str, service_name: str, cluster_name: str) -> bool:
-    materialize(customer_name, service_name, cluster_name)
-
 def materialize(customer_name: str, service_name: str, cluster_name: str) -> bool:
     """
     Render a service and saves it to a file.

--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -105,20 +105,19 @@ def _consolidate_variables(
     """
     We have multiple levels of overrides for our value files.
     1. The values defined inside the service directory as values.yaml.
-    2. overridden by the regional overrides in
-       `service/region_override/region/cluster.yaml`
-    3. overridden by the managed override file. This is like point 2. Conceptually
-       there is no difference, practically this is managed by tools while region
-       overrides are managed manually and they can contain comments. Tools cannot
-       preserve comments.
-    4. overridden by the cluster file. Which is likely going to be replaced by 2 and 3.
-    5. overridden by creating a hierarchical structure. Adding an intermediate directory
+    2. overridden by creating a hierarchical structure. Adding an intermediate directory
        in 'region_override' with a '_values.yaml' file allows to have a common config
        between a set of regions. This is useful if regions in a service are different, but
        subset of them are similar.
-       It works like point 1 and 2 but with an additional layer in between
-    6. overridden by a common '_values.yaml' within a region folder that has a shared config
-       between all clusters in the region. Values in point 2 will still override those values
+    3. overridden by a common '_values.yaml' within a region folder that has a shared config
+       between all clusters in the region.
+    4. overridden by the regional overrides in
+       `service/region_override/region/cluster.yaml`
+    5. overridden by the managed override file. This is like point 2. Conceptually
+       there is no difference, practically this is managed by tools while region
+       overrides are managed manually and they can contain comments. Tools cannot
+       preserve comments.
+    6. overridden by the cluster file. Which is likely going to be replaced by 2 and 3.
 
     TODO: write the minimum components of a yaml parser to remove step 3 and
           patch the regional override preserving comments.

--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -21,7 +21,9 @@ from libsentrykube.service import (
     get_service_values,
     get_service_value_overrides,
     get_tools_managed_service_value_overrides,
-    get_hierarchical_value_overrides, assert_single_cluster_for_customer, get_common_regional_override,
+    get_hierarchical_value_overrides,
+    assert_single_cluster_for_customer,
+    get_common_regional_override,
 )
 from libsentrykube.utils import (
     deep_merge_dict,
@@ -124,7 +126,9 @@ def _consolidate_variables(
     """
 
     # check that there is a single cluster file per customer
-    assert_single_cluster_for_customer(service_name, customer_name, cluster_name, external)
+    assert_single_cluster_for_customer(
+        service_name, customer_name, cluster_name, external
+    )
 
     # Service defaults from _values
     service_values = get_service_values(service_name, external)
@@ -136,7 +140,9 @@ def _consolidate_variables(
 
     if service_value_overrides:
         # Service data overrides from services/SERVICE/region_overrides/REGION/_values.yaml
-        common_service_values = get_common_regional_override(service_name, customer_name, external)
+        common_service_values = get_common_regional_override(
+            service_name, customer_name, external
+        )
         if common_service_values is not None:
             # If a common config file exists then override values with the specific values
             # and override the less specific ones with the result
@@ -158,7 +164,6 @@ def _consolidate_variables(
         service_name, customer_name, cluster_name, external
     )
     deep_merge_dict(service_values, managed_values)
-
 
     # Service data overrides from clusters/
     customer_values, _ = get_service_data(

--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -138,8 +138,8 @@ def _consolidate_variables(
     )
     deep_merge_dict(service_values, managed_values)
 
-    nested_values = get_hierarchical_value_overrides(service_name, customer_name, cluster_name, external)
-    deep_merge_dict(service_values, nested_values)
+    hierarchical_values = get_hierarchical_value_overrides(service_name, customer_name, cluster_name, external)
+    deep_merge_dict(service_values, hierarchical_values)
 
     # Service data overrides from clusters/
     customer_values, _ = get_service_data(

--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -125,7 +125,7 @@ def _consolidate_variables(
           patch the regional override preserving comments.
     """
 
-    # check that there is a single cluster file per customer
+    # check that there is a single customer dir per service
     assert_customer_is_defined_at_most_once(service_name, customer_name, external)
 
     # Service defaults from _values
@@ -150,7 +150,7 @@ def _consolidate_variables(
         # Override with region specific cluster config if exists
         deep_merge_dict(service_values, service_value_overrides)
 
-    # Otherwise we check if it exists in a group in region_overrides/GROUP/REGION
+    # Otherwise merge service data from the within region_overrides/GROUP
     else:
         # Merged data from region_overrides/GROUP/_values.yaml,
         # region_overrides/GROUP/REGION/_values.yaml and

--- a/libsentrykube/service.py
+++ b/libsentrykube/service.py
@@ -7,7 +7,7 @@ import yaml
 from collections import OrderedDict
 from libsentrykube.config import Config
 from libsentrykube.customer import load_customer_data
-from libsentrykube.utils import workspace_root
+from libsentrykube.utils import workspace_root, deep_merge_dict
 
 _services = OrderedDict()
 
@@ -100,9 +100,21 @@ def get_service_value_overrides(
     external: bool = False,
 ) -> dict:
     """
-    For the given service, return the values specified in the corresponding _values.yaml.
+    Loads service configuration with regional and cluster-specific overrides.
 
-    If "external=True" is specified, treat the service name as the full service path.
+    This function implements a two-level configuration system where common regional settings
+    can be shared across all clusters, with cluster-specific overrides on top.
+
+    Directory Structure:
+        region_overrides/
+        └── {region_name}/
+            ├── _values.yaml           # Common settings for all clusters in this region
+            ├── cluster1.yaml          # Cluster-specific overrides
+            └── cluster2.yaml          # Cluster-specific overrides
+
+    Override Precedence (highest to lowest):
+    1. {cluster_name}.yaml            # Cluster-specific settings
+    2. _values.yaml                   # Common regional settings
     """
     try:
         service_override_file = (
@@ -112,9 +124,105 @@ def get_service_value_overrides(
 
         with open(service_override_file, "rb") as f:
             values = yaml.safe_load(f)
+
+        # Try to load the config only after {cluster_name}.yaml was successfully loaded because the common override
+        # only makes sense if there is a cluster config
+        common_override_values = get_common_regional_override(service_name, region_name, external)
+
+        if common_override_values:
+            deep_merge_dict(common_override_values, values)
+            return common_override_values
+
+        return values
     except FileNotFoundError:
-        values = {}
-    return values
+        return {}
+
+def get_common_regional_override(
+        service_name: str,
+        region_name: str,
+        external: bool = False
+) -> dict:
+    """
+    Helper function to load common regional configuration values.
+
+    Looks for a '_values.yaml' file in the region's override directory that contains
+    settings shared across all clusters in that region.
+    """
+    try:
+        common_service_override_file = get_service_value_override_path(service_name, region_name, external) / "_values.yaml"
+
+        with open(common_service_override_file, "rb") as f:
+            common_override_values = yaml.safe_load(f)
+
+        return common_override_values
+    except FileNotFoundError:
+        return {}
+
+def get_hierarchical_value_overrides(
+    service_name: str,
+    region_name: str,
+    cluster_name: str = "default",
+    external: bool = False
+) -> dict:
+    """
+    Enables hierarchical configuration overrides with shared base values.
+
+    This function extends the standard region_overrides system by adding support for
+    shared base configurations. This helps reduce duplication across region-specific
+    configurations.
+
+    Directory Structure:
+        region_overrides/
+        └── common_shared_config/      # Arbitrary name for the shared config group
+            ├── _values.yaml           # Base values for this group
+            └── {region_name}/         # Region-specific overrides
+                └── {cluster_name}.yaml # Cluster-specific overrides
+
+    Override Precedence (highest to lowest):
+    1. region_name/cluster_name.yaml
+    2. common_shared_config/_values.yaml
+    3. Top-level configuration
+    """
+    if external:
+        service_regions_path = workspace_root() / service_name
+    else:
+        service_regions_path = get_service_path(service_name)
+
+    service_regions_path = service_regions_path / "region_overrides"
+
+    if not service_regions_path.exists():
+        return {}
+
+    for override_group in service_regions_path.iterdir():
+        if not override_group.is_dir():
+            continue
+
+        try:
+            service_override_file = (
+                get_service_value_override_path(service_name, override_group.name, external)
+                / "_values.yaml"
+            )
+
+            with open(service_override_file, "rb") as f:
+                base_values = yaml.safe_load(f)
+        except FileNotFoundError:
+            base_values = {}
+
+        region_path = f"{override_group.name}/{region_name}"
+        region_values = get_service_value_overrides(
+            service_name,
+            region_path,
+            cluster_name,
+            external
+        )
+
+        if not region_values:
+            continue
+
+        deep_merge_dict(base_values, region_values)
+        return base_values
+
+    return {}
 
 
 def get_tools_managed_service_value_overrides(

--- a/libsentrykube/service.py
+++ b/libsentrykube/service.py
@@ -24,9 +24,6 @@ def assert_single_cluster_for_customer(
     else:
         service_regions_path = get_service_path(service_name)
 
-    click.echo(f"{service_regions_path}")
-    click.echo(f"expecting {customer_name}/{cluster_name}.yaml")
-
     paths: List[Path] = []
     paths.extend(
         service_regions_path.glob(

--- a/libsentrykube/service.py
+++ b/libsentrykube/service.py
@@ -27,7 +27,7 @@ def assert_single_cluster_for_customer(
     click.echo(f"{service_regions_path}")
     click.echo(f"expecting {customer_name}/{cluster_name}.yaml")
 
-    paths = []
+    paths: List[Path] = []
     paths.extend(
         service_regions_path.glob(
             f"region_overrides/{customer_name}/{cluster_name}.yaml"

--- a/libsentrykube/service.py
+++ b/libsentrykube/service.py
@@ -12,6 +12,11 @@ from libsentrykube.utils import workspace_root, deep_merge_dict
 _services = OrderedDict()
 
 
+class CustomerTooOftenDefinedException(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
 def assert_customer_is_defined_at_most_once(
     service_name: str, customer_name: str, external: bool = False
 ) -> None:
@@ -31,11 +36,9 @@ def assert_customer_is_defined_at_most_once(
     paths.extend(service_regions_path.glob(f"region_overrides/*/{customer_name}"))
 
     if len(paths) > 1:
-        click.echo(f"Expected a single cluster file for customer but got {len(paths)}")
-        click.echo("Found files in:")
-        for path in paths:
-            click.echo(path)
-        raise click.Abort()
+        raise CustomerTooOftenDefinedException(
+            f"Expected a single '{customer_name}' directory in service but found {len(paths)}"
+        )
 
 
 def set_service_paths(service_paths: List[str]):

--- a/libsentrykube/service.py
+++ b/libsentrykube/service.py
@@ -11,7 +11,10 @@ from libsentrykube.utils import workspace_root, deep_merge_dict
 
 _services = OrderedDict()
 
-def assert_single_cluster_for_customer(service_name: str, customer_name: str, cluster_name: str, external: bool = False) -> None:
+
+def assert_single_cluster_for_customer(
+    service_name: str, customer_name: str, cluster_name: str, external: bool = False
+) -> None:
     """
     Make sure that a cluster can only exist once for a service.
     Checks the `region_overrides` and every folder directly in `region_overrides`
@@ -25,8 +28,16 @@ def assert_single_cluster_for_customer(service_name: str, customer_name: str, cl
     click.echo(f"expecting {customer_name}/{cluster_name}.yaml")
 
     paths = []
-    paths.extend(service_regions_path.glob(f"region_overrides/{customer_name}/{cluster_name}.yaml"))
-    paths.extend(service_regions_path.glob(f"region_overrides/*/{customer_name}/{cluster_name}.yaml"))
+    paths.extend(
+        service_regions_path.glob(
+            f"region_overrides/{customer_name}/{cluster_name}.yaml"
+        )
+    )
+    paths.extend(
+        service_regions_path.glob(
+            f"region_overrides/*/{customer_name}/{cluster_name}.yaml"
+        )
+    )
 
     if len(paths) > 1:
         click.echo(f"Expected a single cluster file for customer but got {len(paths)}")
@@ -140,6 +151,7 @@ def get_service_value_overrides(
     except FileNotFoundError:
         return {}
 
+
 def get_common_regional_override(
     service_name: str, region_name: str, external: bool = False
 ) -> Union[dict, None]:
@@ -224,7 +236,9 @@ def get_hierarchical_value_overrides(
             continue
 
         # In order to support _values.yaml files that are shared within the group
-        common_service_values = get_common_regional_override(service_name, region_path, external)
+        common_service_values = get_common_regional_override(
+            service_name, region_path, external
+        )
         if common_service_values is not None:
             deep_merge_dict(common_service_values, region_values)
             deep_merge_dict(base_values, common_service_values)

--- a/libsentrykube/tests/conftest.py
+++ b/libsentrykube/tests/conftest.py
@@ -1,10 +1,7 @@
 import os
-from os import write
-from sys import prefix
 from typing import Iterator, Generator
 import tempfile
 from pathlib import Path
-from venv import create
 
 from yaml import safe_dump
 
@@ -83,12 +80,7 @@ CONFIGURATION = {
     },
 }
 
-TOP_LEVEL_CONFIG = {
-    "config": {
-        "example": "example",
-        "foo": "bar"
-    }
-}
+TOP_LEVEL_CONFIG = {"config": {"example": "example", "foo": "bar"}}
 
 COMMON_SHARED_CONFIG = {
     "config": {"foo": "123", "baz": "test", "settings": {"abc": 10, "def": "test"}}
@@ -97,7 +89,7 @@ COMMON_SHARED_CONFIG = {
 REGIONAL_SHARED_CONFIG = {
     "config": {
         "foo": "regional-foo-will-be-overwritten-by-common-shared-config",
-        "regional": "cool-region"
+        "regional": "cool-region",
     }
 }
 
@@ -160,17 +152,30 @@ def hierarchical_override_structure() -> Generator[str, None, None]:
         k8s = Path(temp_dir) / "k8s"
         create_cluster_data_files(k8s)
 
-        create_structure([
-            "services/my_service/region_overrides/common_shared_config/customer1",
-            "services/another_service"
-        ], root = k8s)
+        create_structure(
+            [
+                "services/my_service/region_overrides/common_shared_config/customer1",
+                "services/another_service",
+            ],
+            root=k8s,
+        )
 
         service_dir = k8s / "services" / "my_service"
 
         write_data_file(service_dir / "_values.yaml", TOP_LEVEL_CONFIG)
 
-        write_data_file(service_dir / "region_overrides" / "common_shared_config" / "_values.yaml", COMMON_SHARED_CONFIG)
-        write_data_file(service_dir / "region_overrides" / "common_shared_config" / "customer1" / "cluster1.yaml", CLUSTER_OVERRIDE_CONFIG)
+        write_data_file(
+            service_dir / "region_overrides" / "common_shared_config" / "_values.yaml",
+            COMMON_SHARED_CONFIG,
+        )
+        write_data_file(
+            service_dir
+            / "region_overrides"
+            / "common_shared_config"
+            / "customer1"
+            / "cluster1.yaml",
+            CLUSTER_OVERRIDE_CONFIG,
+        )
 
         create_cli_config(Path(temp_dir))
 
@@ -200,19 +205,29 @@ def regional_cluster_specific_override_structure() -> Generator[str, None, None]
 
         service_dir = k8s / "services" / "my_service"
 
-        create_structure([
-            "services/my_service/region_overrides/customer1",
-            "services/another_service/"
-        ], root = k8s)
+        create_structure(
+            [
+                "services/my_service/region_overrides/customer1",
+                "services/another_service/",
+            ],
+            root=k8s,
+        )
 
         write_data_file(service_dir / "_values.yaml", TOP_LEVEL_CONFIG)
 
-        write_data_file(service_dir / "region_overrides" / "customer1" / "_values.yaml", COMMON_SHARED_CONFIG)
-        write_data_file(service_dir / "region_overrides" / "customer1" / "cluster1.yaml", CLUSTER_OVERRIDE_CONFIG)
+        write_data_file(
+            service_dir / "region_overrides" / "customer1" / "_values.yaml",
+            COMMON_SHARED_CONFIG,
+        )
+        write_data_file(
+            service_dir / "region_overrides" / "customer1" / "cluster1.yaml",
+            CLUSTER_OVERRIDE_CONFIG,
+        )
 
         create_cli_config(Path(temp_dir))
 
         yield temp_dir
+
 
 @pytest.fixture
 def regional_and_hierarchical_override_structure() -> Generator[str, None, None]:
@@ -238,19 +253,40 @@ def regional_and_hierarchical_override_structure() -> Generator[str, None, None]
         create_cluster_data_files(k8s)
 
         service_dir = k8s / "services" / "my_service"
-        create_structure([
-            "services/my_service/region_overrides/group_one/customer1",
-            "services/another_service"
-        ], root=k8s)
+        create_structure(
+            [
+                "services/my_service/region_overrides/group_one/customer1",
+                "services/another_service",
+            ],
+            root=k8s,
+        )
 
         write_data_file(service_dir / "_values.yaml", TOP_LEVEL_CONFIG)
-        write_data_file(service_dir / "region_overrides" / "group_one" / "_values.yaml", COMMON_SHARED_CONFIG)
-        write_data_file(service_dir / "region_overrides" / "group_one" / "customer1" / "_values.yaml", REGIONAL_SHARED_CONFIG)
-        write_data_file(service_dir / "region_overrides" / "group_one" / "customer1" / "cluster1.yaml", CLUSTER_OVERRIDE_CONFIG)
+        write_data_file(
+            service_dir / "region_overrides" / "group_one" / "_values.yaml",
+            COMMON_SHARED_CONFIG,
+        )
+        write_data_file(
+            service_dir
+            / "region_overrides"
+            / "group_one"
+            / "customer1"
+            / "_values.yaml",
+            REGIONAL_SHARED_CONFIG,
+        )
+        write_data_file(
+            service_dir
+            / "region_overrides"
+            / "group_one"
+            / "customer1"
+            / "cluster1.yaml",
+            CLUSTER_OVERRIDE_CONFIG,
+        )
 
         create_cli_config(Path(temp_dir))
 
         yield temp_dir
+
 
 @pytest.fixture
 def duplicate_customer_clusters_in_service() -> Generator[str, None, None]:
@@ -276,18 +312,32 @@ def duplicate_customer_clusters_in_service() -> Generator[str, None, None]:
 
         service_dir = k8s / "services" / "my_service"
 
-        create_structure([
-            "services/my_service/region_overrides/customer1/",
-            "services/my_service/region_overrides/group_one/customer1/",
-            "services/another_service/"
-        ], root = k8s)
+        create_structure(
+            [
+                "services/my_service/region_overrides/customer1/",
+                "services/my_service/region_overrides/group_one/customer1/",
+                "services/another_service/",
+            ],
+            root=k8s,
+        )
 
-        write_data_file(service_dir / "region_overrides" / "customer1" / "cluster1.yaml", CLUSTER_OVERRIDE_CONFIG)
-        write_data_file(service_dir / "region_overrides" / "group_one" / "customer1" / "cluster1.yaml", CLUSTER_OVERRIDE_CONFIG)
+        write_data_file(
+            service_dir / "region_overrides" / "customer1" / "cluster1.yaml",
+            CLUSTER_OVERRIDE_CONFIG,
+        )
+        write_data_file(
+            service_dir
+            / "region_overrides"
+            / "group_one"
+            / "customer1"
+            / "cluster1.yaml",
+            CLUSTER_OVERRIDE_CONFIG,
+        )
 
         create_cli_config(Path(temp_dir))
 
         yield temp_dir
+
 
 def create_structure(paths: list, root: Path = None) -> None:
     for path in paths:
@@ -296,18 +346,22 @@ def create_structure(paths: list, root: Path = None) -> None:
         else:
             os.makedirs(root / path)
 
+
 def write_data_file(path: Path, data: dict) -> None:
     with open(path, "w") as f:
         f.write(safe_dump(data))
+
 
 def create_cluster_data_files(k8s_root: Path) -> None:
     os.makedirs(k8s_root / "clusters")
     write_data_file(k8s_root / "clusters" / "cluster1.yaml", CLUSTER_1)
     write_data_file(k8s_root / "clusters" / "cluster2.yaml", CLUSTER_2)
 
+
 def create_cli_config(temp_dir: Path) -> None:
     os.makedirs(temp_dir / "cli_config")
     write_data_file(temp_dir / "cli_config" / "configuration.yaml", CONFIGURATION)
+
 
 @pytest.fixture
 def initialized_config_structure(config_structure: str) -> Generator[str, None, None]:

--- a/libsentrykube/tests/conftest.py
+++ b/libsentrykube/tests/conftest.py
@@ -339,12 +339,9 @@ def duplicate_customer_clusters_in_service() -> Generator[str, None, None]:
         yield temp_dir
 
 
-def create_structure(paths: list, root: Path = None) -> None:
+def create_structure(paths: list, root: Path) -> None:
     for path in paths:
-        if root is None:
-            os.makedirs(path)
-        else:
-            os.makedirs(root / path)
+        os.makedirs(root / path)
 
 
 def write_data_file(path: Path, data: dict) -> None:

--- a/libsentrykube/tests/conftest.py
+++ b/libsentrykube/tests/conftest.py
@@ -88,7 +88,7 @@ COMMON_SHARED_CONFIG = {
 
 REGIONAL_SHARED_CONFIG = {
     "config": {
-        "foo": "regional-foo-will-be-overwritten-by-common-shared-config",
+        "foo": "regional-foo-will-be-overwritten-by-cluster-specific-config",
         "regional": "cool-region",
     }
 }
@@ -336,6 +336,115 @@ def duplicate_customer_clusters_in_service() -> Generator[str, None, None]:
 
         create_cli_config(Path(temp_dir))
 
+        yield temp_dir
+
+
+@pytest.fixture
+def duplicate_customer_dirs_in_service() -> Generator[str, None, None]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        k8s = Path(temp_dir) / "k8s"
+        create_cluster_data_files(k8s)
+
+        create_structure(
+            [
+                "services/my_service/region_overrides/customer1/",
+                "services/my_service/region_overrides/group_one/customer1/",
+                "services/another_service/",
+            ],
+            root=k8s,
+        )
+
+        create_cli_config(Path(temp_dir))
+
+        yield temp_dir
+
+
+@pytest.fixture
+def regional_without_cluster_specific_override_structure() -> (
+    Generator[str, None, None]
+):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        k8s = Path(temp_dir) / "k8s"
+        create_cluster_data_files(k8s)
+
+        service_dir = k8s / "services" / "my_service"
+
+        create_structure(
+            [
+                "services/my_service/region_overrides/customer1/",
+                "services/another_service",
+            ],
+            root=k8s,
+        )
+
+        write_data_file(service_dir / "_values.yaml", TOP_LEVEL_CONFIG)
+        write_data_file(
+            service_dir / "region_overrides" / "customer1" / "_values.yaml",
+            REGIONAL_SHARED_CONFIG,
+        )
+
+        create_cli_config(Path(temp_dir))
+
+        yield temp_dir
+
+
+@pytest.fixture
+def hierarchy_without_cluster_specific_override_structure() -> (
+    Generator[str, None, None]
+):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        k8s = Path(temp_dir) / "k8s"
+        create_cluster_data_files(k8s)
+
+        service_dir = k8s / "services" / "my_service"
+
+        create_structure(
+            [
+                "services/my_service/region_overrides/group1/customer1/",
+                "services/another_service",
+            ],
+            root=k8s,
+        )
+
+        write_data_file(service_dir / "_values.yaml", TOP_LEVEL_CONFIG)
+        write_data_file(
+            service_dir / "region_overrides" / "group1" / "_values.yaml",
+            COMMON_SHARED_CONFIG,
+        )
+
+        create_cli_config(Path(temp_dir))
+        yield temp_dir
+
+
+@pytest.fixture
+def hierarchy_with_nested_region_without_cluster_specific_override_structure() -> (
+    Generator[str, None, None]
+):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        k8s = Path(temp_dir) / "k8s"
+        create_cluster_data_files(k8s)
+
+        service_dir = k8s / "services" / "my_service"
+
+        create_structure(
+            [
+                "services/my_service/region_overrides/group1/customer1/",
+                "services/another_service",
+            ],
+            root=k8s,
+        )
+
+        write_data_file(service_dir / "_values.yaml", TOP_LEVEL_CONFIG)
+        write_data_file(
+            service_dir / "region_overrides" / "group1" / "_values.yaml",
+            COMMON_SHARED_CONFIG,
+        )
+        write_data_file(
+            service_dir / "region_overrides" / "group1" / "customer1" / "_values.yaml",
+            REGIONAL_SHARED_CONFIG,
+        )
+
+        create_cli_config(Path(temp_dir))
         yield temp_dir
 
 

--- a/libsentrykube/tests/conftest.py
+++ b/libsentrykube/tests/conftest.py
@@ -1,5 +1,5 @@
 import os
-from typing import Iterator, Generator
+from typing import Iterator, Generator, List
 import tempfile
 from pathlib import Path
 
@@ -339,7 +339,7 @@ def duplicate_customer_clusters_in_service() -> Generator[str, None, None]:
         yield temp_dir
 
 
-def create_structure(paths: list[str], root: Path) -> None:
+def create_structure(paths: List[str], root: Path) -> None:
     for path in paths:
         os.makedirs(root / path)
 

--- a/libsentrykube/tests/conftest.py
+++ b/libsentrykube/tests/conftest.py
@@ -341,6 +341,20 @@ def duplicate_customer_clusters_in_service() -> Generator[str, None, None]:
 
 @pytest.fixture
 def duplicate_customer_dirs_in_service() -> Generator[str, None, None]:
+    """
+    Creates the following folder structure:
+    temp_dir/
+    ├── cli_config/
+    │   └── configuration.yaml
+    └── k8s/
+        └── services/
+            ├── my_service/
+            │   └── region_overrides/
+            │       ├── customer1/
+            │       └── group_one/
+            │           └── customer1/
+            └── another_service/
+    """
     with tempfile.TemporaryDirectory() as temp_dir:
         k8s = Path(temp_dir) / "k8s"
         create_cluster_data_files(k8s)
@@ -363,6 +377,20 @@ def duplicate_customer_dirs_in_service() -> Generator[str, None, None]:
 def regional_without_cluster_specific_override_structure() -> (
     Generator[str, None, None]
 ):
+    """
+    Creates the following folder structure:
+    temp_dir/
+    ├── cli_config/
+    │   └── configuration.yaml
+    └── k8s/
+        └── services/
+            ├── my_service/
+            │   ├── _values.yaml
+            │   └── region_overrides/
+            │       └── customer1/
+            │           └── _values.yaml
+            └── another_service/
+    """
     with tempfile.TemporaryDirectory() as temp_dir:
         k8s = Path(temp_dir) / "k8s"
         create_cluster_data_files(k8s)
@@ -392,6 +420,21 @@ def regional_without_cluster_specific_override_structure() -> (
 def hierarchy_without_cluster_specific_override_structure() -> (
     Generator[str, None, None]
 ):
+    """
+    Creates the following folder structure:
+    temp_dir/
+    ├── cli_config/
+    │   └── configuration.yaml
+    └── k8s/
+        └── services/
+            ├── my_service/
+            │   ├── _values.yaml
+            │   └── region_overrides/
+            │       └── group1/
+            │           ├── _values.yaml
+            │           └── customer1/
+            └── another_service/
+    """
     with tempfile.TemporaryDirectory() as temp_dir:
         k8s = Path(temp_dir) / "k8s"
         create_cluster_data_files(k8s)
@@ -420,6 +463,22 @@ def hierarchy_without_cluster_specific_override_structure() -> (
 def hierarchy_with_nested_region_without_cluster_specific_override_structure() -> (
     Generator[str, None, None]
 ):
+    """
+    Creates the following folder structure:
+    temp_dir/
+    ├── cli_config/
+    │   └── configuration.yaml
+    └── k8s/
+        └── services/
+            ├── my_service/
+            │   ├── _values.yaml
+            │   └── region_overrides/
+            │       └── group1/
+            │           ├── _values.yaml
+            │           └── customer1/
+            │               └── _values.yaml
+            └── another_service/
+    """
     with tempfile.TemporaryDirectory() as temp_dir:
         k8s = Path(temp_dir) / "k8s"
         create_cluster_data_files(k8s)

--- a/libsentrykube/tests/conftest.py
+++ b/libsentrykube/tests/conftest.py
@@ -79,6 +79,26 @@ CONFIGURATION = {
     },
 }
 
+COMMON_SHARED_CONFIG = {
+    "config": {
+        "foo": "123",
+        "baz": "test",
+        "settings": {
+            "abc": 10,
+            "def": "test"
+        }
+    }
+}
+
+CLUSTER_OVERRIDE_CONFIG = {
+    "config": {
+        "foo": "not-foo",
+        "settings": {
+            "abc": 20
+        }
+    }
+}
+
 
 @pytest.fixture
 def config_structure() -> Generator[str, None, None]:
@@ -109,6 +129,74 @@ def config_structure() -> Generator[str, None, None]:
 
         os.makedirs(Path(temp_dir) / "cli_config")
         with open(Path(temp_dir) / "cli_config/configuration.yaml", "w") as f:
+            f.write(safe_dump(CONFIGURATION))
+
+        yield temp_dir
+
+@pytest.fixture
+def hierarchical_override_structure() -> Generator[str, None, None]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        k8s = Path(temp_dir) / "k8s"
+        os.makedirs(k8s / "clusters")
+        clusters = k8s / "clusters"
+        with open(clusters / "cluster1.yaml", "w") as f:
+            f.write(safe_dump(CLUSTER_1))
+        with open(clusters / "cluster2.yaml", "w") as f:
+            f.write(safe_dump(CLUSTER_2))
+
+        service_dir = k8s / "services" / "my_service"
+        region_overrides = service_dir / "region_overrides"
+        os.makedirs(region_overrides)
+        
+        os.makedirs(k8s / "services" / "another_service")
+        common_config = region_overrides / "common_shared_config"
+        os.makedirs(common_config)
+        
+        with open(common_config / "_values.yaml", "w") as f:
+            f.write(safe_dump(COMMON_SHARED_CONFIG))
+
+        region_dir = common_config / "customer1"
+        os.makedirs(region_dir)
+
+        with open(region_dir / "cluster1.yaml", "w") as f:
+            f.write(safe_dump(CLUSTER_OVERRIDE_CONFIG))
+
+        os.makedirs(Path(temp_dir) / "cli_config")
+        with open(Path(temp_dir) / "cli_config" / "configuration.yaml", "w") as f:
+            f.write(safe_dump(CONFIGURATION))
+
+        os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(Path(temp_dir) / "cli_config" / "configuration.yaml")
+
+        yield temp_dir
+
+@pytest.fixture
+def regional_cluster_specific_override_structure() -> Generator[str, None, None]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        k8s = Path(temp_dir) / "k8s"
+        os.makedirs(k8s / "clusters")
+        clusters = k8s / "clusters"
+        with open(clusters / "cluster1.yaml", "w") as f:
+            f.write(safe_dump(CLUSTER_1))
+        with open(clusters / "cluster2.yaml", "w") as f:
+            f.write(safe_dump(CLUSTER_2))
+
+        service_dir = k8s / "services" / "my_service"
+        region_overrides = service_dir / "region_overrides"
+        os.makedirs(region_overrides)
+
+        os.makedirs(k8s / "services" / "another_service")
+
+        region_dir = region_overrides / "customer1"
+        os.makedirs(region_dir)
+
+        with open(region_dir / "_values.yaml", "w") as f:
+            f.write(safe_dump(COMMON_SHARED_CONFIG))
+
+        with open(region_dir / "cluster1.yaml", "w") as f:
+            f.write(safe_dump(CLUSTER_OVERRIDE_CONFIG))
+
+        os.makedirs(Path(temp_dir) / "cli_config")
+        with open(Path(temp_dir) / "cli_config" / "configuration.yaml", "w") as f:
             f.write(safe_dump(CONFIGURATION))
 
         yield temp_dir

--- a/libsentrykube/tests/conftest.py
+++ b/libsentrykube/tests/conftest.py
@@ -1,7 +1,11 @@
 import os
+from os import write
+from sys import prefix
 from typing import Iterator, Generator
 import tempfile
 from pathlib import Path
+from venv import create
+
 from yaml import safe_dump
 
 import pytest
@@ -79,8 +83,22 @@ CONFIGURATION = {
     },
 }
 
+TOP_LEVEL_CONFIG = {
+    "config": {
+        "example": "example",
+        "foo": "bar"
+    }
+}
+
 COMMON_SHARED_CONFIG = {
     "config": {"foo": "123", "baz": "test", "settings": {"abc": 10, "def": "test"}}
+}
+
+REGIONAL_SHARED_CONFIG = {
+    "config": {
+        "foo": "regional-foo-will-be-overwritten-by-common-shared-config",
+        "regional": "cool-region"
+    }
 }
 
 CLUSTER_OVERRIDE_CONFIG = {"config": {"foo": "not-foo", "settings": {"abc": 20}}}
@@ -122,75 +140,174 @@ def config_structure() -> Generator[str, None, None]:
 
 @pytest.fixture
 def hierarchical_override_structure() -> Generator[str, None, None]:
+    """
+    Creates the following folder structure:
+    temp_dir/
+    ├── cli_config/
+    │   └── configuration.yaml
+    └── k8s/
+        └── services/
+            ├── my_service/
+            │   ├── _values.yaml
+            │   └── region_overrides/
+            │       └── common_shared_config/
+            │           ├── _values.yaml
+            │           └── customer1/
+            │               └── cluster1.yaml
+            └── another_service/
+    """
     with tempfile.TemporaryDirectory() as temp_dir:
         k8s = Path(temp_dir) / "k8s"
-        os.makedirs(k8s / "clusters")
-        clusters = k8s / "clusters"
-        with open(clusters / "cluster1.yaml", "w") as f:
-            f.write(safe_dump(CLUSTER_1))
-        with open(clusters / "cluster2.yaml", "w") as f:
-            f.write(safe_dump(CLUSTER_2))
+        create_cluster_data_files(k8s)
+
+        create_structure([
+            "services/my_service/region_overrides/common_shared_config/customer1",
+            "services/another_service"
+        ], root = k8s)
 
         service_dir = k8s / "services" / "my_service"
-        region_overrides = service_dir / "region_overrides"
-        os.makedirs(region_overrides)
 
-        os.makedirs(k8s / "services" / "another_service")
-        common_config = region_overrides / "common_shared_config"
-        os.makedirs(common_config)
+        write_data_file(service_dir / "_values.yaml", TOP_LEVEL_CONFIG)
 
-        with open(common_config / "_values.yaml", "w") as f:
-            f.write(safe_dump(COMMON_SHARED_CONFIG))
+        write_data_file(service_dir / "region_overrides" / "common_shared_config" / "_values.yaml", COMMON_SHARED_CONFIG)
+        write_data_file(service_dir / "region_overrides" / "common_shared_config" / "customer1" / "cluster1.yaml", CLUSTER_OVERRIDE_CONFIG)
 
-        region_dir = common_config / "customer1"
-        os.makedirs(region_dir)
-
-        with open(region_dir / "cluster1.yaml", "w") as f:
-            f.write(safe_dump(CLUSTER_OVERRIDE_CONFIG))
-
-        os.makedirs(Path(temp_dir) / "cli_config")
-        with open(Path(temp_dir) / "cli_config" / "configuration.yaml", "w") as f:
-            f.write(safe_dump(CONFIGURATION))
-
-        os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
-            Path(temp_dir) / "cli_config" / "configuration.yaml"
-        )
+        create_cli_config(Path(temp_dir))
 
         yield temp_dir
 
 
 @pytest.fixture
 def regional_cluster_specific_override_structure() -> Generator[str, None, None]:
+    """
+    Creates the following folder structure:
+    temp_dir/
+    ├── cli_config/
+    │   └── configuration.yaml
+    └── k8s/
+        └── services/
+            ├── my_service/
+            │   ├── _values.yaml
+            │   └── region_overrides/
+            │       └── customer1/
+            │           ├── _values.yaml
+            │           └── cluster1.yaml
+            └── another_service/
+    """
     with tempfile.TemporaryDirectory() as temp_dir:
         k8s = Path(temp_dir) / "k8s"
-        os.makedirs(k8s / "clusters")
-        clusters = k8s / "clusters"
-        with open(clusters / "cluster1.yaml", "w") as f:
-            f.write(safe_dump(CLUSTER_1))
-        with open(clusters / "cluster2.yaml", "w") as f:
-            f.write(safe_dump(CLUSTER_2))
+        create_cluster_data_files(k8s)
 
         service_dir = k8s / "services" / "my_service"
-        region_overrides = service_dir / "region_overrides"
-        os.makedirs(region_overrides)
 
-        os.makedirs(k8s / "services" / "another_service")
+        create_structure([
+            "services/my_service/region_overrides/customer1",
+            "services/another_service/"
+        ], root = k8s)
 
-        region_dir = region_overrides / "customer1"
-        os.makedirs(region_dir)
+        write_data_file(service_dir / "_values.yaml", TOP_LEVEL_CONFIG)
 
-        with open(region_dir / "_values.yaml", "w") as f:
-            f.write(safe_dump(COMMON_SHARED_CONFIG))
+        write_data_file(service_dir / "region_overrides" / "customer1" / "_values.yaml", COMMON_SHARED_CONFIG)
+        write_data_file(service_dir / "region_overrides" / "customer1" / "cluster1.yaml", CLUSTER_OVERRIDE_CONFIG)
 
-        with open(region_dir / "cluster1.yaml", "w") as f:
-            f.write(safe_dump(CLUSTER_OVERRIDE_CONFIG))
-
-        os.makedirs(Path(temp_dir) / "cli_config")
-        with open(Path(temp_dir) / "cli_config" / "configuration.yaml", "w") as f:
-            f.write(safe_dump(CONFIGURATION))
+        create_cli_config(Path(temp_dir))
 
         yield temp_dir
 
+@pytest.fixture
+def regional_and_hierarchical_override_structure() -> Generator[str, None, None]:
+    """
+    Creates the following folder structure:
+    temp_dir/
+    ├── cli_config/
+    │   └── configuration.yaml
+    └── k8s/
+        └── services/
+            ├── my_service/
+            │   ├── _values.yaml
+            │   └── region_overrides/
+            │       └── group_one/
+            │           ├── _values.yaml
+            │           └── customer1/
+            │               ├── _values.yaml
+            │               └── cluster1.yaml
+            └── another_service/
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        k8s = Path(temp_dir) / "k8s"
+        create_cluster_data_files(k8s)
+
+        service_dir = k8s / "services" / "my_service"
+        create_structure([
+            "services/my_service/region_overrides/group_one/customer1",
+            "services/another_service"
+        ], root=k8s)
+
+        write_data_file(service_dir / "_values.yaml", TOP_LEVEL_CONFIG)
+        write_data_file(service_dir / "region_overrides" / "group_one" / "_values.yaml", COMMON_SHARED_CONFIG)
+        write_data_file(service_dir / "region_overrides" / "group_one" / "customer1" / "_values.yaml", REGIONAL_SHARED_CONFIG)
+        write_data_file(service_dir / "region_overrides" / "group_one" / "customer1" / "cluster1.yaml", CLUSTER_OVERRIDE_CONFIG)
+
+        create_cli_config(Path(temp_dir))
+
+        yield temp_dir
+
+@pytest.fixture
+def duplicate_customer_clusters_in_service() -> Generator[str, None, None]:
+    """
+    Creates the following folder structure:
+    temp_dir/
+    ├── cli_config/
+    │   └── configuration.yaml
+    └── k8s/
+        └── services/
+            ├── my_service/
+            │   └── region_overrides/
+            │       ├── customer1/
+            │       │   └── cluster1.yaml
+            │       └── group_one/
+            │           └── customer1/
+            │               └── cluster1.yaml
+            └── another_service/
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        k8s = Path(temp_dir) / "k8s"
+        create_cluster_data_files(k8s)
+
+        service_dir = k8s / "services" / "my_service"
+
+        create_structure([
+            "services/my_service/region_overrides/customer1/",
+            "services/my_service/region_overrides/group_one/customer1/",
+            "services/another_service/"
+        ], root = k8s)
+
+        write_data_file(service_dir / "region_overrides" / "customer1" / "cluster1.yaml", CLUSTER_OVERRIDE_CONFIG)
+        write_data_file(service_dir / "region_overrides" / "group_one" / "customer1" / "cluster1.yaml", CLUSTER_OVERRIDE_CONFIG)
+
+        create_cli_config(Path(temp_dir))
+
+        yield temp_dir
+
+def create_structure(paths: list, root: Path = None) -> None:
+    for path in paths:
+        if root is None:
+            os.makedirs(path)
+        else:
+            os.makedirs(root / path)
+
+def write_data_file(path: Path, data: dict) -> None:
+    with open(path, "w") as f:
+        f.write(safe_dump(data))
+
+def create_cluster_data_files(k8s_root: Path) -> None:
+    os.makedirs(k8s_root / "clusters")
+    write_data_file(k8s_root / "clusters" / "cluster1.yaml", CLUSTER_1)
+    write_data_file(k8s_root / "clusters" / "cluster2.yaml", CLUSTER_2)
+
+def create_cli_config(temp_dir: Path) -> None:
+    os.makedirs(temp_dir / "cli_config")
+    write_data_file(temp_dir / "cli_config" / "configuration.yaml", CONFIGURATION)
 
 @pytest.fixture
 def initialized_config_structure(config_structure: str) -> Generator[str, None, None]:

--- a/libsentrykube/tests/conftest.py
+++ b/libsentrykube/tests/conftest.py
@@ -339,7 +339,7 @@ def duplicate_customer_clusters_in_service() -> Generator[str, None, None]:
         yield temp_dir
 
 
-def create_structure(paths: list, root: Path) -> None:
+def create_structure(paths: list[str], root: Path) -> None:
     for path in paths:
         os.makedirs(root / path)
 

--- a/libsentrykube/tests/test_kube.py
+++ b/libsentrykube/tests/test_kube.py
@@ -1,5 +1,9 @@
+import os
+import click
+
 from libsentrykube.context import init_cluster_context
 from libsentrykube.kube import _consolidate_variables
+from libsentrykube.utils import set_workspace_root_start, workspace_root
 
 expected_consolidated_values = {
     "saas": {
@@ -28,6 +32,13 @@ expected_consolidated_values = {
     }
 }
 
+expected_hierarchical_and_regional_cluster_values = {
+    "config": {"example": "example", "foo": "not-foo", "baz": "test", "settings": {"abc": 20, "def": "test"}}, "key1": "value1"
+}
+
+expected_combined_cluster_values = {
+    "config": {"regional": "cool-region", "example": "example", "foo": "not-foo", "baz": "test", "settings": {"abc": 20, "def": "test"}}, "key1": "value1"
+}
 
 def test_consolidate_variables_not_external():
     region = "saas"
@@ -41,3 +52,64 @@ def test_consolidate_variables_not_external():
             external=False,
         )
         assert returned == expected_consolidated_values[region][cluster][service]
+
+def test_group_hierarchy_consolidation(hierarchical_override_structure: str) -> None:
+    set_workspace_root_start(hierarchical_override_structure)
+    os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
+        workspace_root() / "cli_config/configuration.yaml"
+    )
+    init_cluster_context("customer1", "cluster1")
+
+    returned = _consolidate_variables(
+        customer_name="customer1",
+        service_name="my_service",
+        cluster_name="cluster1",
+        external=False
+    )
+    assert returned == expected_hierarchical_and_regional_cluster_values
+
+def test_cluster_override_consolidation(regional_cluster_specific_override_structure) -> None:
+    set_workspace_root_start(regional_cluster_specific_override_structure)
+    os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
+        workspace_root() / "cli_config/configuration.yaml"
+    )
+    init_cluster_context("customer1", "cluster1")
+
+    returned = _consolidate_variables(
+        customer_name="customer1",
+        service_name="my_service",
+        cluster_name="cluster1",
+        external=False
+    )
+    assert returned == expected_hierarchical_and_regional_cluster_values
+
+def test_hierarchical_and_regional_combined_consolidation(regional_and_hierarchical_override_structure: str):
+    set_workspace_root_start(regional_and_hierarchical_override_structure)
+    os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
+        workspace_root() / "cli_config/configuration.yaml"
+    )
+    init_cluster_context("customer1", "cluster1")
+    returned = _consolidate_variables(
+        customer_name="customer1",
+        service_name="my_service",
+        cluster_name="cluster1",
+        external=False
+    )
+    assert returned == expected_combined_cluster_values
+
+def test_single_customer_cluster_file(duplicate_customer_clusters_in_service: str):
+    try:
+        set_workspace_root_start(duplicate_customer_clusters_in_service)
+        os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
+            workspace_root() / "cli_config/configuration.yaml"
+        )
+        init_cluster_context("customer1", "cluster1")
+        _consolidate_variables(
+            customer_name="customer1",
+            service_name="my_service",
+            cluster_name="cluster1",
+            external=False
+        )
+        pytest.fail("expected exception but got none")
+    except click.exceptions.Abort:
+        pass

--- a/libsentrykube/tests/test_kube.py
+++ b/libsentrykube/tests/test_kube.py
@@ -132,6 +132,7 @@ def test_single_customer_cluster_file(duplicate_customer_clusters_in_service: st
             cluster_name="cluster1",
             external=False,
         )
-        pytest.fail("expected exception but got none")
+        # Fails the test if no exception is raised
+        assert False
     except click.exceptions.Abort:
         pass

--- a/libsentrykube/tests/test_kube.py
+++ b/libsentrykube/tests/test_kube.py
@@ -1,8 +1,9 @@
 import os
-import click
+import pytest
 
 from libsentrykube.context import init_cluster_context
 from libsentrykube.kube import _consolidate_variables
+from libsentrykube.service import CustomerTooOftenDefinedException
 from libsentrykube.utils import set_workspace_root_start, workspace_root
 
 expected_consolidated_values = {
@@ -135,7 +136,7 @@ def test_consolidate_variables_hierarchical_and_regional_combined(
 def test_consolidate_variables_multiple_cluster_files_same_customer(
     duplicate_customer_clusters_in_service: str,
 ):
-    try:
+    with pytest.raises(CustomerTooOftenDefinedException):
         initialize_cluster(duplicate_customer_clusters_in_service)
         _consolidate_variables(
             customer_name="customer1",
@@ -143,16 +144,12 @@ def test_consolidate_variables_multiple_cluster_files_same_customer(
             cluster_name="cluster1",
             external=False,
         )
-        # Fails the test if no exception is raised
-        assert False
-    except click.exceptions.Abort:
-        pass
 
 
 def test_consolidate_variables_multiple_dirs_same_customer(
     duplicate_customer_dirs_in_service: str,
 ):
-    try:
+    with pytest.raises(CustomerTooOftenDefinedException):
         initialize_cluster(duplicate_customer_dirs_in_service)
         _consolidate_variables(
             customer_name="customer1",
@@ -160,9 +157,6 @@ def test_consolidate_variables_multiple_dirs_same_customer(
             cluster_name="cluster1",
             external=False,
         )
-        assert False
-    except click.exceptions.Abort:
-        pass
 
 
 def test_consolidate_variables_regional_config_without_cluster_specific_file(

--- a/libsentrykube/tests/test_kube.py
+++ b/libsentrykube/tests/test_kube.py
@@ -33,12 +33,26 @@ expected_consolidated_values = {
 }
 
 expected_hierarchical_and_regional_cluster_values = {
-    "config": {"example": "example", "foo": "not-foo", "baz": "test", "settings": {"abc": 20, "def": "test"}}, "key1": "value1"
+    "config": {
+        "example": "example",
+        "foo": "not-foo",
+        "baz": "test",
+        "settings": {"abc": 20, "def": "test"},
+    },
+    "key1": "value1",
 }
 
 expected_combined_cluster_values = {
-    "config": {"regional": "cool-region", "example": "example", "foo": "not-foo", "baz": "test", "settings": {"abc": 20, "def": "test"}}, "key1": "value1"
+    "config": {
+        "regional": "cool-region",
+        "example": "example",
+        "foo": "not-foo",
+        "baz": "test",
+        "settings": {"abc": 20, "def": "test"},
+    },
+    "key1": "value1",
 }
+
 
 def test_consolidate_variables_not_external():
     region = "saas"
@@ -53,6 +67,7 @@ def test_consolidate_variables_not_external():
         )
         assert returned == expected_consolidated_values[region][cluster][service]
 
+
 def test_group_hierarchy_consolidation(hierarchical_override_structure: str) -> None:
     set_workspace_root_start(hierarchical_override_structure)
     os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
@@ -64,11 +79,14 @@ def test_group_hierarchy_consolidation(hierarchical_override_structure: str) -> 
         customer_name="customer1",
         service_name="my_service",
         cluster_name="cluster1",
-        external=False
+        external=False,
     )
     assert returned == expected_hierarchical_and_regional_cluster_values
 
-def test_cluster_override_consolidation(regional_cluster_specific_override_structure) -> None:
+
+def test_cluster_override_consolidation(
+    regional_cluster_specific_override_structure,
+) -> None:
     set_workspace_root_start(regional_cluster_specific_override_structure)
     os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
         workspace_root() / "cli_config/configuration.yaml"
@@ -79,11 +97,14 @@ def test_cluster_override_consolidation(regional_cluster_specific_override_struc
         customer_name="customer1",
         service_name="my_service",
         cluster_name="cluster1",
-        external=False
+        external=False,
     )
     assert returned == expected_hierarchical_and_regional_cluster_values
 
-def test_hierarchical_and_regional_combined_consolidation(regional_and_hierarchical_override_structure: str):
+
+def test_hierarchical_and_regional_combined_consolidation(
+    regional_and_hierarchical_override_structure: str,
+):
     set_workspace_root_start(regional_and_hierarchical_override_structure)
     os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
         workspace_root() / "cli_config/configuration.yaml"
@@ -93,9 +114,10 @@ def test_hierarchical_and_regional_combined_consolidation(regional_and_hierarchi
         customer_name="customer1",
         service_name="my_service",
         cluster_name="cluster1",
-        external=False
+        external=False,
     )
     assert returned == expected_combined_cluster_values
+
 
 def test_single_customer_cluster_file(duplicate_customer_clusters_in_service: str):
     try:
@@ -108,7 +130,7 @@ def test_single_customer_cluster_file(duplicate_customer_clusters_in_service: st
             customer_name="customer1",
             service_name="my_service",
             cluster_name="cluster1",
-            external=False
+            external=False,
         )
         pytest.fail("expected exception but got none")
     except click.exceptions.Abort:

--- a/libsentrykube/tests/test_service.py
+++ b/libsentrykube/tests/test_service.py
@@ -218,10 +218,10 @@ def test_get_hierarchical_value_overrides(
     assert returned == expected_hierarchical_and_regional_cluster_values
 
 def test_regional_cluster_value_overrides(
-    regional_override_structure: str
+    regional_cluster_specific_override_structure: str
 ) -> None:
     start_workspace_root = workspace_root().as_posix()
-    set_workspace_root_start(regional_override_structure)
+    set_workspace_root_start(regional_cluster_specific_override_structure)
     os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
         workspace_root() / "cli_config/configuration.yaml"
     )

--- a/libsentrykube/tests/test_service.py
+++ b/libsentrykube/tests/test_service.py
@@ -208,9 +208,9 @@ def test_get_hierarchical_value_overrides(hierarchical_override_structure: str) 
     assert returned == expected_hierarchical_and_regional_cluster_values
 
 
-def test_regional_cluster_value_overrides(regional_override_structure: str) -> None:
+def test_regional_cluster_value_overrides(test_regional_cluster_value_overrides: str) -> None:
     start_workspace_root = workspace_root().as_posix()
-    set_workspace_root_start(regional_override_structure)
+    set_workspace_root_start(test_regional_cluster_value_overrides)
     os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
         workspace_root() / "cli_config/configuration.yaml"
     )

--- a/libsentrykube/tests/test_service.py
+++ b/libsentrykube/tests/test_service.py
@@ -208,9 +208,9 @@ def test_get_hierarchical_value_overrides(hierarchical_override_structure: str) 
     assert returned == expected_hierarchical_and_regional_cluster_values
 
 
-def test_regional_cluster_value_overrides(test_regional_cluster_value_overrides: str) -> None:
+def test_regional_cluster_value_overrides(regional_cluster_specific_override_structure: str) -> None:
     start_workspace_root = workspace_root().as_posix()
-    set_workspace_root_start(test_regional_cluster_value_overrides)
+    set_workspace_root_start(regional_cluster_specific_override_structure)
     os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
         workspace_root() / "cli_config/configuration.yaml"
     )

--- a/libsentrykube/tests/test_service.py
+++ b/libsentrykube/tests/test_service.py
@@ -209,7 +209,7 @@ def test_get_hierarchical_value_overrides(hierarchical_override_structure: str) 
 
 
 def test_regional_cluster_value_overrides(
-        regional_cluster_specific_override_structure: str
+    regional_cluster_specific_override_structure: str,
 ) -> None:
     start_workspace_root = workspace_root().as_posix()
     set_workspace_root_start(regional_cluster_specific_override_structure)

--- a/libsentrykube/tests/test_service.py
+++ b/libsentrykube/tests/test_service.py
@@ -1,6 +1,7 @@
 from libsentrykube.context import init_cluster_context
 import os
 from libsentrykube.service import (
+    get_hierarchical_value_overrides,
     get_service_data,
     get_service_values,
     get_service_value_overrides,
@@ -59,6 +60,17 @@ expected_service_value_managed_overrides = {
                 }
             },
             "service2": {},
+        }
+    }
+}
+
+expected_hierarchical_and_regional_cluster_values = {
+    "config": {
+        "foo": "not-foo",
+        "baz": "test",
+        "settings": {
+            "abc": 20,
+            "def": "test"
         }
     }
 }
@@ -186,3 +198,39 @@ def test_write_managed_file(config_structure) -> None:
     assert path.is_file()
 
     set_workspace_root_start(start_workspace_root)
+
+def test_get_hierarchical_value_overrides(
+    hierarchical_override_structure: str
+) -> None:
+    start_workspace_root = workspace_root().as_posix()
+    set_workspace_root_start(hierarchical_override_structure)
+    os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
+        workspace_root() / "cli_config/configuration.yaml"
+    )
+    init_cluster_context("customer1", "cluster1")
+    
+    returned = get_hierarchical_value_overrides(
+        service_name="my_service",
+        region_name="customer1",
+        cluster_name="cluster1"
+    )
+    
+    assert returned == expected_hierarchical_and_regional_cluster_values
+
+def test_regional_cluster_value_overrides(
+    regional_override_structure: str
+) -> None:
+    start_workspace_root = workspace_root().as_posix()
+    set_workspace_root_start(regional_override_structure)
+    os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
+        workspace_root() / "cli_config/configuration.yaml"
+    )
+    init_cluster_context("customer1", "cluster1")
+
+    returned = get_service_value_overrides(
+        service_name="my_service",
+        region_name="customer1",
+        cluster_name="cluster1",
+    )
+
+    assert returned == expected_hierarchical_and_regional_cluster_values

--- a/libsentrykube/tests/test_service.py
+++ b/libsentrykube/tests/test_service.py
@@ -1,5 +1,6 @@
 from libsentrykube.context import init_cluster_context
 import os
+
 from libsentrykube.service import (
     get_hierarchical_value_overrides,
     get_service_data,
@@ -66,6 +67,13 @@ expected_service_value_managed_overrides = {
 
 expected_hierarchical_and_regional_cluster_values = {
     "config": {"foo": "not-foo", "baz": "test", "settings": {"abc": 20, "def": "test"}}
+}
+
+expected_regional_cluster_values = {
+    "config": {
+        "foo": "not-foo",
+        "settings": {"abc": 20},
+    }
 }
 
 
@@ -222,4 +230,4 @@ def test_regional_cluster_value_overrides(
         cluster_name="cluster1",
     )
 
-    assert returned == expected_hierarchical_and_regional_cluster_values
+    assert returned == expected_regional_cluster_values

--- a/libsentrykube/tests/test_service.py
+++ b/libsentrykube/tests/test_service.py
@@ -194,7 +194,6 @@ def test_write_managed_file(config_structure) -> None:
 
 
 def test_get_hierarchical_value_overrides(hierarchical_override_structure: str) -> None:
-    start_workspace_root = workspace_root().as_posix()
     set_workspace_root_start(hierarchical_override_structure)
     os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
         workspace_root() / "cli_config/configuration.yaml"
@@ -211,7 +210,6 @@ def test_get_hierarchical_value_overrides(hierarchical_override_structure: str) 
 def test_regional_cluster_value_overrides(
     regional_cluster_specific_override_structure: str,
 ) -> None:
-    start_workspace_root = workspace_root().as_posix()
     set_workspace_root_start(regional_cluster_specific_override_structure)
     os.environ["SENTRY_KUBE_CONFIG_FILE"] = str(
         workspace_root() / "cli_config/configuration.yaml"

--- a/libsentrykube/utils.py
+++ b/libsentrykube/utils.py
@@ -365,7 +365,8 @@ def deep_merge_dict(
 
     for k, v in other.items():
         if v is None:
-            into.pop(k)
+            if k in into:
+                into.pop(k)
         elif k in into and isinstance(v, dict) and isinstance(into[k], dict):
             deep_merge_dict(into=into[k], other=v, overwrite=overwrite)
         elif k in into:


### PR DESCRIPTION
This PR adds two possibilities to share common config between cluster configs.

* Hierarchical Sharing: it is possible to introduce an additional directory between `region_overrides` and `region_name` with arbitrary names. This directory can contain a `_values.yaml` file with config values where all values from `region_name/cluster.yaml` are merged into.
* Cluster Sharing: it is possible to add a `_values.yaml` file into `region_overrides/region_name` which works conceptually the same as the hierarchical sharing but it makes more sense if many cluster files exist in a region