### PR TITLE
feat: Allow additional locals to md5template

### DIFF
--- a/libsentrykube/ext.py
+++ b/libsentrykube/ext.py
@@ -335,7 +335,9 @@ class Md5Template(Md5File):
     """
 
     @pass_context
-    def run(self, context, template_path: str, extra_context: Optional[dict] = None) -> str:  # type: ignore
+    def run(
+        self, context, template_path: str, extra_context: Optional[dict] = None
+    ) -> str:  # type: ignore
         return md5_fileobj(
             io.BytesIO(
                 self.environment.get_template(template_path)

--- a/libsentrykube/ext.py
+++ b/libsentrykube/ext.py
@@ -335,11 +335,11 @@ class Md5Template(Md5File):
     """
 
     @pass_context
-    def run(self, context, template_path: str) -> str:  # type: ignore
+    def run(self, context, template_path: str, extra_context: Optional[dict] = None) -> str:  # type: ignore
         return md5_fileobj(
             io.BytesIO(
                 self.environment.get_template(template_path)
-                .render(context)
+                .render(context, **(extra_context or {}))
                 .encode("utf-8")
             )
         )


### PR DESCRIPTION
This way, some templates can be run with additional context, and made
reusable, see https://github.com/getsentry/ops/pull/13275
