### PR TITLE
fix(kube): Ignore empty override files

### DIFF
--- a/libsentrykube/service.py
+++ b/libsentrykube/service.py
@@ -93,10 +93,9 @@ def get_service_values(service_name: str, external: bool = False) -> dict:
         service_path = get_service_path(service_name)
     try:
         with open(service_path / "_values.yaml", "rb") as f:
-            values = yaml.safe_load(f)
+            return yaml.safe_load(f) or {}
     except FileNotFoundError:
-        values = {}
-    return values
+        return {}
 
 
 def get_service_value_override_path(
@@ -139,7 +138,7 @@ def get_service_value_overrides(
         )
 
         with open(service_override_file, "rb") as f:
-            values = yaml.safe_load(f)
+            values = yaml.safe_load(f) or {}
 
         return values
     except FileNotFoundError:
@@ -162,9 +161,7 @@ def get_common_regional_override(
         )
 
         with open(common_service_override_file, "rb") as f:
-            common_override_values = yaml.safe_load(f)
-
-        return common_override_values
+            return yaml.safe_load(f) or {}
     except FileNotFoundError:
         return {}
 
@@ -214,7 +211,7 @@ def get_hierarchical_value_overrides(
             )
 
             with open(service_override_file, "rb") as f:
-                base_values = yaml.safe_load(f)
+                base_values = yaml.safe_load(f) or {}
         except FileNotFoundError:
             base_values = {}
 
@@ -268,7 +265,7 @@ def get_tools_managed_service_value_overrides(
 
     if service_override_file.exists() and service_override_file.is_file():
         with open(service_override_file, "rb") as f:
-            return yaml.safe_load(f)
+            return yaml.safe_load(f) or {}
 
     return {}
 


### PR DESCRIPTION
When a region override exists, but it is empty, parsing fails. Instead the empty file should just be treated as empty.

`safe_load` returns `None` if the file contains no YAML documents (aka when it is empty).

Came up in: https://github.com/getsentry/ops/pull/13594

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/sentry_kube/validate_services.py", line 89, in <module>
    test_services()
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/sentry_kube/validate_services.py", line 56, in test_services
    lint_errors_count += lint_and_print(
                         ^^^^^^^^^^^^^^^
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/libsentrykube/lint.py", line 185, in lint_and_print
    for doc in rendered:
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/libsentrykube/kube.py", line 199, in render_services
    out = render_templates(
          ^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/libsentrykube/kube.py", line [22](https://github.com/getsentry/ops/actions/runs/12765101378/job/35578617967?pr=13594#step:7:23)8, in render_templates
    render_data["values"] = _consolidate_variables(
                            ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/libsentrykube/kube.py", line 158, in _consolidate_variables
    hierarchical_values = get_hierarchical_value_overrides(
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/libsentrykube/service.py", line [23](https://github.com/getsentry/ops/actions/runs/12765101378/job/35578617967?pr=13594#step:7:24)8, in get_hierarchical_value_overrides
    deep_merge_dict(base_values, region_values)
  File "/home/runner/work/ops/ops/.venv/lib/python3.11/site-packages/libsentrykube/utils.py", line 366, in deep_merge_dict
    for k, v in other.items():
                ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'items'
```