### PR TITLE
Increase default kube api timeout

### DIFF
--- a/libsentrykube/ext.py
+++ b/libsentrykube/ext.py
@@ -23,7 +23,7 @@ from libsentrykube.utils import (
     workspace_root,
 )
 
-KUBE_API_TIMEOUT_DEFAULT: int = 1
+KUBE_API_TIMEOUT_DEFAULT: int = 3
 KUBE_API_TIMEOUT_ENV_NAME: str = "SK_KUBE_TIMEOUT"
 
 ENVOY_ENTRYPOINT = """


### PR DESCRIPTION
Some of our SREs were experiencing regular timeouts when communicating with clusters in `jp`.

Increase default timeout from 1s -> 3s to provide a bit of wiggle room for global communication.