### PR TITLE
change: Add get-var macro

### DIFF
--- a/libsentrykube/ext.py
+++ b/libsentrykube/ext.py
@@ -810,3 +810,23 @@ class MachineType(SimpleExtension):
                 }
                 return self._type_cache[name]
         return {}
+
+
+class GetVar(SimpleExtension):
+    """
+    This only exists because jinja2 doesn't support macros that return values.
+
+    Allows to search for variable value in a list of dictionaries to implement
+    common patterns of get from override dict or default one.
+    Examples:
+
+    params.var|default(defaults.var) =>  get_var(var_name, params, defaults)
+    params.get(var, component.get(var, service.get("some global default"))) => get_var(var, params, component, service, default="some global default")
+    """
+
+    @cache
+    def run(self, key: str, *dicts: Dict[str, Any], default: str | None = None):
+        for d in dicts:
+            if key in d:
+                return d[key]
+        return default

--- a/libsentrykube/setup.py
+++ b/libsentrykube/setup.py
@@ -24,6 +24,7 @@ default_macros = [
     "xds_proxy_sidecar=libsentrykube.ext:XDSProxySidecar",
     "xds_proxy_initcontainer=libsentrykube.ext:XDSProxyInitContainer",
     "xds_proxy_volume=libsentrykube.ext:XDSProxyVolume",
+    "get_var=libsentrykube.ext:GetVar",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ macros = [
     "xds_proxy_volume=libsentrykube.ext:XDSProxyVolume",
     "service_registry_annotations=libsentrykube.ext:ServiceRegistryAnnotations",
     "service_registry_labels=libsentrykube.ext:ServiceRegistryLabels",
+    "get_var=libsentrykube.ext:GetVar",
 ]
 
 


### PR DESCRIPTION
There is common pattern of having a default variable value for service, redefinition for environment, redefinition for component + some hardcoded default in yaml itself.

This macro allows to convert chains like this
```
{% set sdk_environment = params.sdk_environment|default(values.sdk_environment)|default(customer.sentry_region) %}
```
into this
```
{% set sdk_environment = get_var('sdk_environment', params, values, customer)
```