### PR TITLE
fix: Support .yaml.j2 extensions for templates

### DIFF
--- a/libsentrykube/service.py
+++ b/libsentrykube/service.py
@@ -322,7 +322,7 @@ def get_service_template_files(service_name):
 
     for template in service_dir.iterdir():
         if not template.name.startswith("_") and template.name.endswith(
-            (".yaml", ".yml")
+            (".yaml", ".yml", ".yaml.j2", ".yml.j2")
         ):
             yield template
 


### PR DESCRIPTION
We should support .j2 extensions since these are Jinja2 files.