### PR TITLE
fix(resources): Give service name which is updated

### DIFF
--- a/libsentrykube/reversemap.py
+++ b/libsentrykube/reversemap.py
@@ -72,7 +72,7 @@ def extract_clusters(resources: Set[ResourceReference]) -> Set[ResourceReference
                 ResourceReference(
                     customer_name=r.customer_name,
                     cluster_name=r.cluster_name,
-                    service_name=None,
+                    service_name=r.service_name,
                 )
             )
 


### PR DESCRIPTION
Triggering materialization based on changed files renders all services. See PR https://github.com/getsentry/ops/pull/14643, more specifically this run https://github.com/getsentry/ops/actions/runs/14097771384/job/39488225134?pr=14643

Fixed it so we only run materialization on the changed services. Locally it works
```bash
python -m sentry_kube.render_services k8s/services/vroom/deployment.yaml
Service materialized: ly : default : vroom
Service materialized: saas : default : vroom
Service materialized: goldmansachs : default : vroom
Service materialized: geico : default : vroom
Service materialized: disney : default : vroom
Service materialized: s4s : default : vroom
Service materialized: de : default : vroom
I made changes to the materialized config. Please stage them and commit again.
```