### PR TITLE
feat(kubectl): remove old private DNS connection to clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ sentry-kube --help
 * `SENTRY_KUBE_CONFIG_FILE`: Set this to the full path of the configuration file that contains the clusters and customers configuration for sentry-kube. It defaults to `[workspace_root]/cli_config/configuration.yaml`
 * `SENTRY_KUBE_ENABLE_NOTIFICATIONS`: Set `SENTRY_KUBE_ENABLE_NOTIFICATIONS=1` to enable MacOS notifications for things like `sentry-kube connect` bastion connections
 * `SENTRY_KUBE_KUBECTL_DIFF_CONCURRENCY`: Set `SENTRY_KUBE_KUBECTL_DIFF_CONCURRENCY` to make `kubectl diff` process objects in parallel
-* `SENTRY_KUBE_IAP`: Access Kubernetes API through Google Identity-Aware Proxy and a jump host instead of standard bastion and sshuttle.
 * `SENTRY_KUBE_KUBECTL_VERSION`: Set `SENTRY_KUBE_KUBECTL_VERSION=1.22.17` to configure the kubectl version to use
 * `SENTRY_KUBE_NO_CONTEXT`: Set `SENTRY_KUBE_NO_CONTEXT=1` to skip checking for a functional kube context
 * `SENTRY_KUBE_ROOT`: Sets the workspace root. It defaults to the git root directory.

--- a/libsentrykube/iap.py
+++ b/libsentrykube/iap.py
@@ -1,14 +1,9 @@
 import os
-import socket
 import subprocess
-import time
-from contextlib import closing
-from urllib.parse import urlparse
 
 import click
 import yaml
 
-from libsentrykube.ssh import build_ssh_command
 
 KUBE_CONFIG_PATH = os.getenv(
     "KUBECONFIG_PATH",
@@ -21,45 +16,29 @@ KUBECTL_JUMP_HOST = os.getenv(
 )
 
 
-def _tcp_port_check(port: int) -> bool:
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-        # The error indicator is 0 if the operation succeeded, otherwise the value of the
-        # errno variable.
-        return sock.connect_ex(("127.0.0.1", port)) == 0
-
-
-def _dns_check() -> None:
-    try:
-        socket.gethostbyname("kubernetes")
-    except socket.gaierror:
-        raise RuntimeError(
-            "Need to make host 'kubernetes' resolved to localhost\n\n"
-            "Action:\n"
-            "- You need to add an entry to /etc/hosts, like\n\n"
-            "127.0.0.1       kubernetes\n"
-        )
-
-
-def _dns_endpoint_check(control_plane_host: str, quiet: bool) -> bool:
+def _is_external_connection_allowed(
+    project: str, region: str, cluster_name: str
+) -> bool:
     """
-    GKE provides a DNS endpoint for the control plane, but also a private IP endpoint.
-    We want to use the DNS endpoint if possible as it doesn't require port forwarding or bastion hosts,
-    but if it's not available, we'll use the private IP endpoint.
-
-    We can detect the endpoint by checking if the control plane host contains "gke.goog".
-    Example DNS endpoint: gke-22df3be7a2d24d7eb1935c53b5cfaa2337ea-249720712700.us-east1.gke.goog
+    Check if external connections are enabled for the cluster.
     """
-
-    if "gke.goog" in control_plane_host:
-        use_dns_endpoint = True
-        if not quiet:
-            click.echo(f"GKE DNS endpoint detected ({control_plane_host})")
-    else:
-        use_dns_endpoint = False
-        if not quiet:
-            click.echo(f"GKE private IP endpoint detected ({control_plane_host})")
-
-    return use_dns_endpoint
+    is_enabled = subprocess.check_output(
+        [
+            "gcloud",
+            "container",
+            "clusters",
+            "describe",
+            cluster_name,
+            "--region",
+            region,
+            "--project",
+            project,
+            "--format",
+            "value(controlPlaneEndpointsConfig.dnsEndpointConfig.allowExternalTraffic)",
+        ],
+    )
+    res = is_enabled.decode("utf-8").strip()
+    return True if res == "True" else False
 
 
 def ensure_iap_tunnel(ctx: click.core.Context, quiet: bool = False) -> str:
@@ -71,6 +50,7 @@ def ensure_iap_tunnel(ctx: click.core.Context, quiet: bool = False) -> str:
     """
     port: int = ctx.obj.cluster.services_data["iap_local_port"]
     context = ctx.obj.context_name
+    _, project, region, cluster = context.split("_")
 
     with open(KUBE_CONFIG_PATH) as kubeconfig_file:
         kubeconfig = yaml.safe_load(kubeconfig_file)
@@ -80,71 +60,21 @@ def ensure_iap_tunnel(ctx: click.core.Context, quiet: bool = False) -> str:
                 break
         else:
             # example: gke_internal-sentry_us-central1-b_zdpwkxst
-            _, project, region, cluster = context.split("_")
             raise ValueError(
                 f"Can't find k8s cluster for {context} context. You might need to run:\n"
                 f"gcloud container clusters get-credentials {cluster} "
                 f"--region {region} --project {project}"
             )
-
-        _dns_check()
-        control_plane_host = urlparse(cluster["cluster"]["server"]).hostname
-        use_dns_endpoint = _dns_endpoint_check(control_plane_host, quiet)
-
-        if not use_dns_endpoint:
-            cluster["cluster"]["server"] = f"https://kubernetes:{port}"
+        if not _is_external_connection_allowed(project, region, cluster):
+            raise ValueError(
+                f"External connections are not allowed for cluster {cluster} in"
+                f"region {region}, project {project}."
+            )
 
         tmp_kubeconfig_path = os.path.join(
             os.path.dirname(KUBE_CONFIG_PATH), f"sentry-kube.config.{port}.yaml"
         )
         with open(tmp_kubeconfig_path, "w") as tmp_cf:
             yaml.dump(kubeconfig, tmp_cf)
-
-    if use_dns_endpoint:
-        return tmp_kubeconfig_path
-
-    # Skip all of this junk if we're using the DNS endpoint
-    port_fwd = f"{port}:{control_plane_host}:443"
-    if not _tcp_port_check(port):
-        if not quiet:
-            click.echo(f"Spawning port forwarding for {port_fwd}")
-
-        subprocess.Popen(
-            build_ssh_command(
-                ctx,
-                host=KUBECTL_JUMP_HOST,
-                project=None,
-                user=None,
-                ssh_key_file=None,
-                # -N -- Do not execute remote command
-                # -T -- do not allocate tty
-                # -f -- go to background, before the command execution
-                # ExitOnForwardFailure=yes
-                # Terminate the connection if it cannot set up all requested dynamic,
-                # tunnel, local, and remote port forwardings.
-                ssh_args=(
-                    "-NTf",
-                    "-o",
-                    "ExitOnForwardFailure=yes",
-                    "-L",
-                    port_fwd,
-                ),
-            ),
-            # spawn as detached process
-            start_new_session=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.STDOUT,
-        )
-        # try port_check_attempts times if the port forwarding is in place
-        port_check_attempts = 10
-        for _ in range(port_check_attempts):
-            if not quiet:
-                click.echo("poking on port ...")
-            if _tcp_port_check(port):
-                if not quiet:
-                    click.echo("port forwarding in place")
-                break
-            else:
-                time.sleep(3)
 
     return tmp_kubeconfig_path

--- a/libsentrykube/iap.py
+++ b/libsentrykube/iap.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 
 import click
 import yaml
@@ -10,38 +9,8 @@ KUBE_CONFIG_PATH = os.getenv(
     os.path.expanduser("~/.kube/config"),
 )
 
-KUBECTL_JUMP_HOST = os.getenv(
-    "SENTRY_KUBE_KUBECTL_JUMP_HOST",
-    "scratch",
-)
 
-
-def _is_external_connection_allowed(
-    project: str, region: str, cluster_name: str
-) -> bool:
-    """
-    Check if external connections are enabled for the cluster.
-    """
-    is_enabled = subprocess.check_output(
-        [
-            "gcloud",
-            "container",
-            "clusters",
-            "describe",
-            cluster_name,
-            "--region",
-            region,
-            "--project",
-            project,
-            "--format",
-            "value(controlPlaneEndpointsConfig.dnsEndpointConfig.allowExternalTraffic)",
-        ],
-    )
-    res = is_enabled.decode("utf-8").strip()
-    return True if res == "True" else False
-
-
-def ensure_iap_tunnel(ctx: click.core.Context, quiet: bool = False) -> str:
+def ensure_iap_tunnel(ctx: click.core.Context) -> str:
     """
     Create an IAP tunnel and generate a temporary kubeconfig that uses it.
 
@@ -50,7 +19,6 @@ def ensure_iap_tunnel(ctx: click.core.Context, quiet: bool = False) -> str:
     """
     port: int = ctx.obj.cluster.services_data["iap_local_port"]
     context = ctx.obj.context_name
-    _, project, region, cluster = context.split("_")
 
     with open(KUBE_CONFIG_PATH) as kubeconfig_file:
         kubeconfig = yaml.safe_load(kubeconfig_file)
@@ -60,15 +28,11 @@ def ensure_iap_tunnel(ctx: click.core.Context, quiet: bool = False) -> str:
                 break
         else:
             # example: gke_internal-sentry_us-central1-b_zdpwkxst
+            _, project, region, cluster = context.split("_")
             raise ValueError(
                 f"Can't find k8s cluster for {context} context. You might need to run:\n"
                 f"gcloud container clusters get-credentials {cluster} "
                 f"--region {region} --project {project}"
-            )
-        if not _is_external_connection_allowed(project, region, cluster):
-            raise ValueError(
-                f"External connections are not allowed for cluster {cluster} in"
-                f"region {region}, project {project}."
             )
 
         tmp_kubeconfig_path = os.path.join(

--- a/libsentrykube/tests/test_iap.py
+++ b/libsentrykube/tests/test_iap.py
@@ -1,12 +1,30 @@
-from libsentrykube.iap import _is_external_connection_allowed
 from unittest import mock
+import json
+from libsentrykube.iap import ensure_iap_tunnel
+
+dummy_kube_config = json.dumps(
+    {
+        "clusters": [
+            {
+                "certificate-authority-data": "secure-data",
+                "server": "server-url",
+                "name": "gke_test-proj_test-region_test-cluster",
+            }
+        ]
+    }
+)
 
 
-@mock.patch("subprocess.check_output")
-def test_external_connection_allowed(mock_subprocess):
-    mock_subprocess.return_value = b"True\n"
-    result = _is_external_connection_allowed(
-        "test-project", "us-central1", "test-cluster"
+@mock.patch("builtins.open", new_callable=mock.mock_open, read_data=dummy_kube_config)
+@mock.patch("yaml.dump")
+@mock.patch("os.getenv", return_value="/tmp/kubeconfig")
+def test_ensure_iap_tunnel(mock_getenv, mock_yaml_dump, mock_open) -> None:
+    mock_ctx = mock.Mock()
+    mock_ctx.obj.cluster.services_data.__getitem__ = mock.Mock(return_value=8080)
+    mock_ctx.obj.context_name = "gke_test-proj_test-region_test-cluster"
+    ensure_iap_tunnel(mock_ctx)
+
+    mock_yaml_dump.assert_called_once_with(
+        json.loads(dummy_kube_config),
+        mock.ANY,
     )
-
-    assert result is True

--- a/libsentrykube/tests/test_iap.py
+++ b/libsentrykube/tests/test_iap.py
@@ -1,14 +1,12 @@
-from libsentrykube.iap import _dns_endpoint_check
+from libsentrykube.iap import _is_external_connection_allowed
+from unittest import mock
 
 
-def test_dns_endpoint_detects_valid_host():
-    use_dns_endpoint = _dns_endpoint_check(
-        control_plane_host="gke-22df3be7a2d24d7eb1935c53b5cfaa2337ea-249720712700.us-east1.gke.goog",
-        quiet=True,
+@mock.patch("subprocess.check_output")
+def test_external_connection_allowed(mock_subprocess):
+    mock_subprocess.return_value = b"True\n"
+    result = _is_external_connection_allowed(
+        "test-project", "us-central1", "test-cluster"
     )
-    assert use_dns_endpoint is True
 
-
-def test_dns_endpoint_detects_invalid_host():
-    use_dns_endpoint = _dns_endpoint_check(control_plane_host="172.16.0.13", quiet=True)
-    assert use_dns_endpoint is False
+    assert result is True

--- a/sentry_kube/cli/__init__.py
+++ b/sentry_kube/cli/__init__.py
@@ -194,7 +194,7 @@ Valid regions:
             service_monitors=customer_config.service_monitors,
         )
 
-        os.environ["KUBECONFIG"] = kubeconfig = ensure_iap_tunnel(ctx, quiet)
+        os.environ["KUBECONFIG"] = kubeconfig = ensure_iap_tunnel(ctx)
 
         kube_set_context(context_name, kubeconfig=kubeconfig)
 


### PR DESCRIPTION
Originally, we had to connect to GKE clusters via some DNS hacking & port forwarding.
GCP now officially supports connecting to clusters via an external DNS endpoint (which we added in #72), this removes the old way of connecting (and doesn't require people to update their `/etc/hosts` anymore)