### PR TITLE
sentry-kube pg: support optional namespace via /

### DIFF
--- a/sentry_kube/cli/pg/create_user.py
+++ b/sentry_kube/cli/pg/create_user.py
@@ -153,7 +153,9 @@ def upload_plaintext_to_k8s_secret(
             is_modified = True
 
     if not is_modified:
-        print(f"Kubernetes secret `{namespace}/{secret_name}` is up to date. No new users.")
+        print(
+            f"Kubernetes secret `{namespace}/{secret_name}` is up to date. No new users."
+        )
         return
     print(f"### Kubernetes secret `{namespace}/{secret_name}`, AFTER")
     for secret_item in secret_data:

--- a/sentry_kube/tests/cli/test_pg.py
+++ b/sentry_kube/tests/cli/test_pg.py
@@ -66,7 +66,7 @@ def test_secret_does_not_exist(mock_stdout):
     core_api_mock.read_namespaced_secret.side_effect = ApiException(status=404)
 
     users = {}
-    upload_plaintext_to_k8s_secret(core_api_mock, users, "example")
+    upload_plaintext_to_k8s_secret(core_api_mock, users, "default", "example")
     output = mock_stdout.getvalue()
 
     assert core_api_mock.create_namespaced_secret.call_count == 1
@@ -95,7 +95,7 @@ def test_secret_add_user(mock_stdout):
         }
     }
 
-    upload_plaintext_to_k8s_secret(core_api_mock, users, "example")
+    upload_plaintext_to_k8s_secret(core_api_mock, users, "default", "example")
     output = mock_stdout.getvalue()
 
     assert core_api_mock.patch_namespaced_secret.call_count == 1


### PR DESCRIPTION
It will be possible to create plaintext secrets in namespaces other than `default`, for example:
```
sentry-kube -C s4s pg create-user --generate-plaintext --plaintext-k8s-secret sentry-system/datadog --username kafka-password
```

P.S. At this point, `pg` subcommand could also be used for creating secrets for systems other than Postgres, so we may consider renaming it.