### PR TITLE
Revert "chore: Add config defaults"

### DIFF
--- a/cli_config/configuration.yaml
+++ b/cli_config/configuration.yaml
@@ -7,4 +7,6 @@ silo_regions:
       cluster_def_root: clusters/us
       materialized_manifests: materialized_manifests/us
     sentry_region: us
-    service_monitors: { getsentry: [123456789] }
+    service_monitors: {
+      getsentry: [ 123456789 ]
+    }

--- a/libsentrykube/tests/config.yaml
+++ b/libsentrykube/tests/config.yaml
@@ -21,8 +21,3 @@ silo_regions:
       materialized_manifests: rendered_services
       materialized_helm_values: rendered_helm_values
     sentry_region: st-my_other_customer
-  region2:
-    k8s:
-      root: k8s
-    sentry_region: region2
-  region3:

--- a/libsentrykube/tests/test_config.py
+++ b/libsentrykube/tests/test_config.py
@@ -41,26 +41,4 @@ def test_config_load() -> None:
             sentry_region="st-my_other_customer",
             service_monitors=MappingProxyType({}),
         ),
-        "region2": SiloRegion(
-            k8s_config=K8sConfig(
-                root="k8s",
-                cluster_def_root="clusters/region2",
-                cluster_name=None,
-                materialized_manifests="materialized_manifests/region2",
-                materialized_helm_values="materialized_helm_values/region2",
-            ),
-            sentry_region="region2",
-            service_monitors=MappingProxyType({}),
-        ),
-        "region3": SiloRegion(
-            k8s_config=K8sConfig(
-                root="k8s",
-                cluster_def_root="clusters/region3",
-                cluster_name=None,
-                materialized_manifests="materialized_manifests/region3",
-                materialized_helm_values="materialized_helm_values/region3",
-            ),
-            sentry_region="region3",
-            service_monitors=MappingProxyType({}),
-        ),
     }


### PR DESCRIPTION
Reverts getsentry/sentry-infra-tools#65 the default assumptions break our event reporting so this needs to be reworked.