### PR TITLE
feat(sentry-kube): support combining files with keyword

### DIFF
--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -120,6 +120,20 @@ def _consolidate_variables(
        preserve comments.
     6. overridden by the cluster file. Which is likely going to be replaced by 2 and 3.
 
+    ***
+    For all levels of overrides listed above, in the same directory of file system, we support
+    merging separete values files together, before proceding with the overriding logic 
+    Most common examples (numbers refer to override level listed above):
+    1. `k8s/services/getsentry/_values.yaml` content will be combined with `k8s/services/getsentry/_values_consumers.yaml`
+    3. `k8s/services/getsentry/regional_overrides/s4s/_values.yaml` content will be combined with
+       `k8s/services/getsentry/regional_overrides/s4s/_values_consumers.yaml`
+    4. `k8s/services/seer/region_overrides/de/default.yaml` content will be combined with `k8s/services/seer/region_overrides/de/default_2.yaml`
+    Files that should be combined have constraints:
+    - files cannot have conflicting keys. It will fail.
+    - files must be in the same directory in the file system
+    - file names must start with `_values` to be combined with `_values.yaml` file, or must start with `<cluster>` to be combined with `<cluster>.yaml`
+
+
     TODO: write the minimum components of a yaml parser to remove step 3 and
           patch the regional override preserving comments.
     """

--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -122,7 +122,7 @@ def _consolidate_variables(
 
     ***
     For all levels of overrides listed above, in the same directory of file system, we support
-    merging separete values files together, before proceding with the overriding logic 
+    merging separete values files together, before proceding with the overriding logic
     Most common examples (numbers refer to override level listed above):
     1. `k8s/services/getsentry/_values.yaml` content will be combined with `k8s/services/getsentry/_values_consumers.yaml`
     3. `k8s/services/getsentry/regional_overrides/s4s/_values.yaml` content will be combined with

--- a/libsentrykube/tests/k8s_root/services/service1/_values_consumers.yaml
+++ b/libsentrykube/tests/k8s_root/services/service1/_values_consumers.yaml
@@ -1,0 +1,6 @@
+consumer_key1: value1
+consumer_key2:
+  subkey2_1: value2_1
+  subkey2_2: 2
+  subkey2_3:
+    - value2_3_1

--- a/libsentrykube/tests/k8s_root/services/service1/region_overrides/us/customer.managed.yaml
+++ b/libsentrykube/tests/k8s_root/services/service1/region_overrides/us/customer.managed.yaml
@@ -3,3 +3,8 @@ key2:
     - value2_4_1_managed_replaced
   subkey2_5:
     - value2_5_1_managed_replaced
+consumer_key2:
+  subkey2_4:
+    - value2_4_1_managed_replaced
+  subkey2_5:
+    - value2_5_1_managed_replaced

--- a/libsentrykube/tests/k8s_root/services/service1/region_overrides/us/customer_consumers.yaml
+++ b/libsentrykube/tests/k8s_root/services/service1/region_overrides/us/customer_consumers.yaml
@@ -1,0 +1,5 @@
+consumer_key2:
+  subkey2_3:
+    - value2_3_1_replaced
+  subkey2_4:
+    - value2_4_1_replaced

--- a/libsentrykube/tests/test_kube.py
+++ b/libsentrykube/tests/test_kube.py
@@ -22,6 +22,18 @@ expected_consolidated_values = {
                         "value2_5_1_managed_replaced"
                     ],  # From the managed file
                 },
+                "consumer_key1": "value1",
+                "consumer_key2": {
+                    "subkey2_1": "value2_1",  # From the value file
+                    "subkey2_2": 2,  # From the value file
+                    "subkey2_3": ["value2_3_1_replaced"],  # From the region override
+                    "subkey2_4": [
+                        "value2_4_1_managed_replaced"
+                    ],  # From the managed file
+                    "subkey2_5": [
+                        "value2_5_1_managed_replaced"
+                    ],  # From the managed file
+                },
             },
             "service2": {
                 "key3": "three",  # From the cluster file


### PR DESCRIPTION
**Context:**
streaming team needs github CODEOWNERS to consumer values so they can merge changes without depending on SRE aproval


**PR explained:**
for every level of overriding logic, find all files that start with the keyword (usually it will be the default value of `_values`) and combine them together, before proceeding with the original overriding logic

**Impacts:**
for services that only has one `_values.yaml` file, this changes nothing

**Rollout plan:**
after this PR is merged, cut a new release, update sentrykubelib version in ops, then make a new `_consumer_values.yaml` file in `getsentry` service, in all overriding levels