### PR TITLE
feat: support region aliases

### DIFF
--- a/cli_config/configuration.yaml
+++ b/cli_config/configuration.yaml
@@ -2,11 +2,10 @@
 # for each silo-region (region or single tenant).
 silo_regions:
   saas:
+    aliases: [us]
     k8s:
       root: k8s
       cluster_def_root: clusters/us
       materialized_manifests: materialized_manifests/us
     sentry_region: us
-    service_monitors: {
-      getsentry: [ 123456789 ]
-    }
+    service_monitors: { getsentry: [123456789] }

--- a/cli_config/configuration.yaml
+++ b/cli_config/configuration.yaml
@@ -2,7 +2,7 @@
 # for each silo-region (region or single tenant).
 silo_regions:
   saas:
-    aliases: [us]
+    aliases: [saasalias]
     k8s:
       root: k8s
       cluster_def_root: clusters/us

--- a/libsentrykube/config.py
+++ b/libsentrykube/config.py
@@ -59,6 +59,7 @@ class K8sConfig:
 
 @dataclass(frozen=True)
 class SiloRegion:
+    aliases: list[str]
     k8s_config: K8sConfig
     sentry_region: str
     service_monitors: MappingProxyType[str, list[int]]
@@ -67,6 +68,7 @@ class SiloRegion:
     def from_conf(cls, silo_regions_conf: Mapping[str, Any]) -> SiloRegion:
         k8s_config = silo_regions_conf["k8s"]
         return SiloRegion(
+            aliases=silo_regions_conf.get("aliases", []),
             k8s_config=K8sConfig.from_conf(k8s_config),
             sentry_region=silo_regions_conf.get("sentry_region", "unknown"),
             service_monitors=silo_regions_conf.get("service_monitors", {}),

--- a/libsentrykube/tests/config.yaml
+++ b/libsentrykube/tests/config.yaml
@@ -1,5 +1,6 @@
 silo_regions:
   saas:
+    aliases: [us]
     k8s:
       root: k8s_root
       # relative to k8s root

--- a/libsentrykube/tests/config.yaml
+++ b/libsentrykube/tests/config.yaml
@@ -1,6 +1,6 @@
 silo_regions:
   saas:
-    aliases: ['us']
+    aliases: ['saasalias']
     k8s:
       root: k8s_root
       # relative to k8s root

--- a/libsentrykube/tests/config.yaml
+++ b/libsentrykube/tests/config.yaml
@@ -1,6 +1,6 @@
 silo_regions:
   saas:
-    aliases: [us]
+    aliases: ['us']
     k8s:
       root: k8s_root
       # relative to k8s root

--- a/libsentrykube/tests/test_config.py
+++ b/libsentrykube/tests/test_config.py
@@ -9,7 +9,7 @@ def test_config_load() -> None:
 
     assert conf.silo_regions == {
         "saas": SiloRegion(
-            aliases=["us"],
+            aliases=["saasalias"],
             k8s_config=K8sConfig(
                 root="k8s_root",
                 cluster_def_root="clusters/saas",

--- a/libsentrykube/tests/test_config.py
+++ b/libsentrykube/tests/test_config.py
@@ -9,6 +9,7 @@ def test_config_load() -> None:
 
     assert conf.silo_regions == {
         "saas": SiloRegion(
+            aliases=["us"],
             k8s_config=K8sConfig(
                 root="k8s_root",
                 cluster_def_root="clusters/saas",
@@ -20,6 +21,7 @@ def test_config_load() -> None:
             service_monitors=MappingProxyType({}),
         ),
         "my_customer": SiloRegion(
+            aliases=[],
             k8s_config=K8sConfig(
                 root="k8s_root",
                 cluster_def_root="clusters/my_customer",
@@ -31,6 +33,7 @@ def test_config_load() -> None:
             service_monitors=MappingProxyType({}),
         ),
         "my_other_customer": SiloRegion(
+            aliases=[],
             k8s_config=K8sConfig(
                 root="k8s_root",
                 cluster_def_root="clusters/my_other_customer",

--- a/sentry_kube/cli/__init__.py
+++ b/sentry_kube/cli/__init__.py
@@ -131,15 +131,24 @@ Valid regions:
 """
             )
 
+        customer_config = None
+        # Load the region if it exists in the config
         if customer in config.silo_regions:
             customer_config = config.silo_regions[customer]
         else:
-            print(
-                f"""Invalid region specified, must be one of:
-{newline_customers}
-"""
-            )
-            exit(1)
+            # Check if we have any aliases that match our region
+            for region in config.silo_regions:
+                if customer in config.silo_regions[region].aliases:
+                    customer_config = config.silo_regions[region]
+                    break
+
+            if customer_config is None:
+                print(
+                    f"""Invalid region specified, must be one of:
+    {newline_customers}
+    """
+                )
+                exit(1)
 
         if not quiet:
             click.echo(f"Operating for customer {customer}.")


### PR DESCRIPTION
We want to fix some bad region naming, this allows regions to be referenced by an alias so we don't have to have duplicate regions in our config leading to other messes.