### PR TITLE
chore(pgbouncer): use auth unconditionally

### DIFF
--- a/sentry_kube/ext.py
+++ b/sentry_kube/ext.py
@@ -97,7 +97,7 @@ class PGBouncerSidecar(SimpleExtension):
         livenessProbe: Optional[dict] = None,
         resources: Optional[dict] = None,
         custom_pre_stop_command: Optional[str] = None,
-        use_auth: bool = False,
+        use_auth: bool = True,
     ):
         if application_name:
             # Prepend supplied application_name to the pgbouncer options
@@ -123,21 +123,9 @@ class PGBouncerSidecar(SimpleExtension):
         if custom_pre_stop_command:
             pre_stop_command = custom_pre_stop_command
 
-        stats_users_statement = "stats_users = datadog\n"
-        userlist_init_cmd = ""
-        if not use_auth:
-            stats_users_statement = ""
-            userlist_init_cmd = """cat << EOF > /etc/pgbouncer/userlist.txt
-"postgres" ""
-"maintenance" ""
-EOF
-"""
-
         image = f"{repository}/pgbouncer:{version}"
         if ".pkg.dev/" in repository:
             image = f"{repository}/pgbouncer/image:{version}"
-
-        admin_user = "pgbouncer" if use_auth else "postgres"
 
         res: dict[str, Any] = {
             "image": image,
@@ -145,20 +133,18 @@ EOF
             "args": [
                 "/bin/sh",
                 "-ec",
-                userlist_init_cmd
-                + f"""cat << EOF > /etc/pgbouncer.ini
+                f"""cat << EOF > /etc/pgbouncer.ini
 [databases]
 {databases_str}
 [pgbouncer]
 listen_addr = 0.0.0.0
 listen_port = 6432
 unix_socket_dir =
-auth_type = {"scram-sha-256" if use_auth else "trust"}
+auth_type = scram-sha-256
 auth_file = /etc/pgbouncer/userlist.txt
-admin_users = {admin_user}
-"""
-                + stats_users_statement
-                + f"""pool_mode = transaction
+admin_users = pgbouncer
+stats_users = datadog
+pool_mode = transaction
 server_reset_query = DISCARD ALL
 ignore_startup_parameters = extra_float_digits
 server_check_query = select 1
@@ -193,15 +179,14 @@ exec su-exec pgbouncer pgbouncer /etc/pgbouncer.ini""",
         }
         _resources.update(resources or {})
         res["resources"] = _resources
-        if use_auth:
-            res["volumeMounts"] = [
-                {
-                    "name": "pgbouncer-secrets",
-                    "subPath": "userlist",
-                    "mountPath": "/etc/pgbouncer/userlist.txt",
-                    "readOnly": True,
-                }
-            ]
+        res["volumeMounts"] = [
+            {
+                "name": "pgbouncer-secrets",
+                "subPath": "userlist",
+                "mountPath": "/etc/pgbouncer/userlist.txt",
+                "readOnly": True,
+            }
+        ]
         if livenessProbe:
             res["livenessProbe"] = livenessProbe
         return json.dumps(res)


### PR DESCRIPTION
We already have `use_auth=True` in all invocations of `pgbouncer_sidecar()` so it should be fine to remove unused code.

Tested with:
```
pip install -e ~/code/sentry-infra-tools

make materialize-k8s-service service=getsentry
make materialize-k8s-service-st service=getsentry
# ^renders no changes
```