### PR TITLE
feat(run-pod): add `--no-security-context` option

### DIFF
--- a/sentry_kube/cli/run_pod.py
+++ b/sentry_kube/cli/run_pod.py
@@ -160,6 +160,12 @@ _DEFAULT_STR = "__default__"
     help="Used with `--exec` to allocate TTY for containers. Default `False`",
 )
 @click.option(
+    "--no-security-context",
+    is_flag=True,
+    default=False,
+    help="Remove any securityContext options.",
+)
+@click.option(
     "--root",
     is_flag=True,
     default=False,
@@ -194,6 +200,7 @@ def run_pod(
     exec_,
     interactive,
     tty,
+    no_security_context,
     root,
     safe_to_evict,
     memory,
@@ -334,6 +341,9 @@ def run_pod(
     container.pop("livenessProbe", None)
     container.pop("readinessProbe", None)
     container.pop("startupProbe", None)
+
+    if no_security_context:
+        container.pop("securityContext", None)
 
     if root:
         container.setdefault("securityContext", {})["runAsUser"] = 0


### PR DESCRIPTION
Allows to specify `--no-security-context` option that strips the `securityContext` section from run-pod's pod.
```
$ sentry-kube -qC s4s run-pod -s getsentry -d web --no-security-context
No Pods found for deletion.
Pod created: sk-run-pod-oioki-2025-06-27-15-33-51

$ sentry-kube -qC s4s kubectl exec -it sk-run-pod-oioki-2025-06-27-15-33-51 -c sentry /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
root@sk-run-pod-oioki-2025-06-27-15-33-51:/usr/src/getsentry# touch hello
root@sk-run-pod-oioki-2025-06-27-15-33-51:/usr/src/getsentry# id
uid=0(root) gid=0(root) groups=0(root)
```