### PR TITLE
feat(sentry-kube): add `debug` subcommand

### DIFF
--- a/libsentrykube/utils.py
+++ b/libsentrykube/utils.py
@@ -26,7 +26,7 @@ from yaml import SafeDumper, safe_dump_all, safe_load_all
 # kubectl is supported within one minor version (older or newer) of kube-apiserver.
 # Also, you'll want to upgrade the python kubernetes client version accordingly.
 KUBECTL_BINARY = os.environ.get("SENTRY_KUBE_KUBECTL_BINARY", "kubectl")
-KUBECTL_VERSION = os.environ.get("SENTRY_KUBE_KUBECTL_VERSION", "1.30.4")
+KUBECTL_VERSION = os.environ.get("SENTRY_KUBE_KUBECTL_VERSION", "1.31.10")
 ENABLE_NOTIFICATIONS = os.environ.get("SENTRY_KUBE_ENABLE_NOTIFICATIONS", False)
 
 _kube_client = None

--- a/sentry_kube/cli/debug.py
+++ b/sentry_kube/cli/debug.py
@@ -115,7 +115,7 @@ def debug(ctx, container, image, namespace, quiet):
 
     custom_debug_profile = {
         # set the same env and volumeMounts as of the original container
-        "env": container_spec["env"],
+        "env": container_spec["env"] if "env" in container_spec else [],
         "volumeMounts": volume_mounts,
         # drop security features
         "securityContext": {

--- a/sentry_kube/cli/debug.py
+++ b/sentry_kube/cli/debug.py
@@ -1,0 +1,114 @@
+import subprocess
+
+import click
+import json
+import tempfile
+
+from libsentrykube.utils import ensure_kubectl, should_run_with_empty_context
+
+
+__all__ = ("debug",)
+
+
+@click.command(
+    add_help_option=False,
+    context_settings=dict(allow_extra_args=True, allow_interspersed_args=False, ignore_unknown_options=True),
+)
+@click.option("--container", "-c")
+@click.option("--image", "-i")
+@click.option("--namespace", "-n", default="default")
+@click.option("--quiet", "-q", is_flag=True)
+@click.pass_context
+def debug(ctx, container, image, namespace, quiet):
+    """
+    Convenient wrapper for running "kubectl debug" with env and volume mounts
+    """
+    args = ctx.args
+    context = ctx.obj.context_name
+    customer = ctx.obj.customer_name
+    quiet = ctx.obj.quiet_mode or quiet
+
+    cmd = [f"{ensure_kubectl()}"]
+    if not should_run_with_empty_context():
+        cmd += ["--context", context]
+
+    pod_name = args[0]
+
+    from kubernetes import client as k8s_client
+    from libsentrykube.kube import kube_get_client
+
+    api = k8s_client.CoreV1Api(kube_get_client())
+    api_client = k8s_client.ApiClient()
+
+    # read spec of the target pod
+    resp = api.read_namespaced_pod(namespace=namespace, name=pod_name)
+    # convert to camelCase
+    resp = api_client.sanitize_for_serialization(resp)
+
+    # for writing the custom debug profile
+    tmp = tempfile.NamedTemporaryFile(delete=True)
+
+    if container:
+        container_spec = next((item for item in resp["spec"]["containers"] if item["name"] == container), None)
+    else:
+        container_spec = resp["spec"]["containers"][0]
+        container = container_spec["name"]
+
+    # use the target pod image by default
+    if not image:
+        image = container_spec["image"]
+
+    cmd += [
+        "debug",
+        "-it",
+        f"--image={image}",
+        f"--target={container}",
+        f"--custom={tmp.name}",
+    ]
+    cmd += list(args)
+
+    if not quiet:
+        click.echo(
+            "Running the following for customer "
+            f"{click.style(customer, fg='yellow', bold=True)}:\n\n"
+            f"+ {' '.join(cmd)}"
+        )
+        click.echo()
+
+    volume_mounts = container_spec["volumeMounts"]
+    mount_instructions = ""
+    for vm in volume_mounts:
+        if "subPath" in vm:
+            del vm["subPath"]
+            original_mount_path = vm["mountPath"]
+            original_mount_dir = "/".join(vm["mountPath"].split("/")[:-1])
+            new_mount_path = f"/subPathMounts{original_mount_dir}"
+            vm["mountPath"] = new_mount_path
+            mount_instructions += f"  mkdir -p {original_mount_dir}\n"
+            mount_instructions += f"  ln -sf /subPathMounts{original_mount_path} {original_mount_path}\n"
+
+    if mount_instructions:
+        click.echo("Subpath mounts are not allowed for ephemeral containers.")
+        click.echo("https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1EphemeralContainer.md")
+        click.echo("However, you can achieve almost the same by running:")
+        click.echo(mount_instructions)
+
+    custom_debug_profile = {
+        # set the same env and volumeMounts as of the original container
+        "env": container_spec["env"],
+        "volumeMounts": volume_mounts,
+        # drop security features
+        "securityContext": {
+            "allowPrivilegeEscalation": True,
+            "readOnlyRootFilesystem": False,
+            "runAsNonRoot": False,
+            "runAsUser": 0,
+            "runAsGroup": 0,
+        },
+    }
+
+    # write the custom debug profile
+    tmp.write(json.dumps(custom_debug_profile).encode("utf-8"))
+    tmp.flush()
+
+    subprocess.run(cmd, check=False)

--- a/sentry_kube/cli/debug.py
+++ b/sentry_kube/cli/debug.py
@@ -12,7 +12,11 @@ __all__ = ("debug",)
 
 @click.command(
     add_help_option=False,
-    context_settings=dict(allow_extra_args=True, allow_interspersed_args=False, ignore_unknown_options=True),
+    context_settings=dict(
+        allow_extra_args=True,
+        allow_interspersed_args=False,
+        ignore_unknown_options=True,
+    ),
 )
 @click.option("--container", "-c")
 @click.option("--image", "-i")
@@ -49,7 +53,10 @@ def debug(ctx, container, image, namespace, quiet):
     tmp = tempfile.NamedTemporaryFile(delete=True)
 
     if container:
-        container_spec = next((item for item in resp["spec"]["containers"] if item["name"] == container), None)
+        container_spec = next(
+            (item for item in resp["spec"]["containers"] if item["name"] == container),
+            None,
+        )
     else:
         container_spec = resp["spec"]["containers"][0]
         container = container_spec["name"]
@@ -85,11 +92,15 @@ def debug(ctx, container, image, namespace, quiet):
             new_mount_path = f"/subPathMounts{original_mount_dir}"
             vm["mountPath"] = new_mount_path
             mount_instructions += f"  mkdir -p {original_mount_dir}\n"
-            mount_instructions += f"  ln -sf /subPathMounts{original_mount_path} {original_mount_path}\n"
+            mount_instructions += (
+                f"  ln -sf /subPathMounts{original_mount_path} {original_mount_path}\n"
+            )
 
     if mount_instructions:
         click.echo("Subpath mounts are not allowed for ephemeral containers.")
-        click.echo("https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1EphemeralContainer.md")
+        click.echo(
+            "https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1EphemeralContainer.md"
+        )
         click.echo("However, you can achieve almost the same by running:")
         click.echo(mount_instructions)
 

--- a/sentry_kube/cli/debug.py
+++ b/sentry_kube/cli/debug.py
@@ -65,7 +65,11 @@ def debug(ctx, container, image, namespace, quiet):
         container = container_spec["name"]
     else:
         container_spec = next(
-            (item for item in resp["spec"]["containers"] if item["name"] not in EXCLUDED_CONTAINERS),
+            (
+                item
+                for item in resp["spec"]["containers"]
+                if item["name"] not in EXCLUDED_CONTAINERS
+            ),
             None,
         )
         container = container_spec["name"]

--- a/sentry_kube/cli/kubectl.py
+++ b/sentry_kube/cli/kubectl.py
@@ -10,7 +10,7 @@ __all__ = ("kubectl",)
 
 @click.command(
     add_help_option=False,
-    context_settings=dict(allow_extra_args=True, ignore_unknown_options=True),
+    context_settings=dict(allow_extra_args=True, allow_interspersed_args=False, ignore_unknown_options=True),
 )
 @click.option("--yes", "-y", is_flag=True)
 @click.option("--quiet", "-q", is_flag=True)

--- a/sentry_kube/cli/kubectl.py
+++ b/sentry_kube/cli/kubectl.py
@@ -10,7 +10,11 @@ __all__ = ("kubectl",)
 
 @click.command(
     add_help_option=False,
-    context_settings=dict(allow_extra_args=True, allow_interspersed_args=False, ignore_unknown_options=True),
+    context_settings=dict(
+        allow_extra_args=True,
+        allow_interspersed_args=False,
+        ignore_unknown_options=True,
+    ),
 )
 @click.option("--yes", "-y", is_flag=True)
 @click.option("--quiet", "-q", is_flag=True)


### PR DESCRIPTION
Use [kubectl debug](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_debug/) subcommand but with some additions:
* use the same image for debug as the original container being debugged;
* remove security features for debug purposes (read-only file system, low-privileged user).

Thanks to [custom profiling in kubectl debug](https://kubernetes.io/blog/2024/08/22/kubernetes-1-31-custom-profiling-kubectl-debug/) (since 1.31 hence the version bump):
* pass the same env variables as the original container;
* attach the same volumes as the original container;
* however, some volumes (with `subPath`) are disallowed for ephemeral containers, hence we do the symlink workaround.

Try it out locally:
```
pip install -e /Users/oioki/code/sentry-infra-tools
```

Example of usage:
```
$ sentry-kube -q debug snuba-api-5dd6fd5fbd-kvbdd -- /bin/bash
Subpath mounts are not allowed for ephemeral containers.
https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1EphemeralContainer.md
However, you can achieve almost the same by running:
  mkdir -p /etc/snuba
  ln -sf /subPathMounts/etc/snuba/prod_settings.py /etc/snuba/prod_settings.py
  mkdir -p /usr/src/snuba
  ln -sf /subPathMounts/usr/src/snuba/docker_entrypoint.sh /usr/src/snuba/docker_entrypoint.sh

Targeting container "snuba". If you don't see processes from this container it may be because the container runtime doesn't support this feature.
Defaulting debug container name to debugger-gwmjm.
If you don't see a command prompt, try pressing enter.
root@snuba-api-5dd6fd5fbd-kvbdd:/usr/src/snuba# id
uid=0(root) gid=0(root) groups=0(root)
root@snuba-api-5dd6fd5fbd-kvbdd:/usr/src/snuba# touch writable-filesystem.txt
root@snuba-api-5dd6fd5fbd-kvbdd:/usr/src/snuba# env | grep KAFKA_SASL_MECHANISM
KAFKA_SASL_MECHANISM=SCRAM-SHA-256
```

