### PR TITLE
feat: Allow setting an override image SHA from the CLI for applies

### DIFF
--- a/libsentrykube/ext.py
+++ b/libsentrykube/ext.py
@@ -142,6 +142,9 @@ class DeploymentImage(SimpleExtension):
         if "KUBERNETES_OFFLINE" in os.environ:
             return default
 
+        if "DEPLOYMENT_IMAGE" in os.environ:
+            return os.getenv("DEPLOYMENT_IMAGE")
+
         namespace, name = kube_extract_namespace(deployment_name)
         client = kube_get_client()
         try:

--- a/sentry_kube/cli/apply.py
+++ b/sentry_kube/cli/apply.py
@@ -426,7 +426,7 @@ def diff(
 )
 @click.option(
     "--deployment-image",
-    type=str | None,
+    type=str,
     help="Override the deployment image for the services",
 )
 @click.pass_context

--- a/sentry_kube/cli/apply.py
+++ b/sentry_kube/cli/apply.py
@@ -313,6 +313,15 @@ def render(ctx, services, raw, pager, filters, materialize, use_canary: bool):
             click.echo("".join(rendered))
 
 
+def _set_deployment_image(services: List[str], deployment_image: str | None) -> None:
+    if len(services) > 1 and deployment_image:
+        raise click.BadArgumentUsage(
+            "Cannot specify --deployment-image with multiple services"
+        )
+    elif deployment_image:
+        os.environ["DEPLOYMENT_IMAGE"] = deployment_image
+
+
 @click.command()
 @click.pass_context
 @click.option("--filter", "filters", multiple=True)
@@ -359,12 +368,7 @@ def diff(
     This is non-destructive and tells you what would be applied, if
     anything, with your current changes.
     """
-    if len(services) > 1 and deployment_image:
-        raise click.BadArgumentUsage(
-            "Cannot specify --deployment-image with multiple services"
-        )
-    elif deployment_image:
-        os.environ["DEPLOYMENT_IMAGE"] = deployment_image
+    _set_deployment_image(services, deployment_image)
 
     click.echo(f"Rendering services: {', '.join(services)}")
     skip_kinds = ("Job",) if not allow_jobs else None
@@ -458,12 +462,7 @@ def apply(
     allow_jobs: bool,
     deployment_image: str | None = None,
 ):
-    if len(services) > 1 and deployment_image:
-        raise click.BadArgumentUsage(
-            "Cannot specify --deployment-image with multiple services"
-        )
-    elif deployment_image:
-        os.environ["DEPLOYMENT_IMAGE"] = deployment_image
+    _set_deployment_image(services, deployment_image)
 
     customer_name = ctx.obj.customer_name
     service_monitors = ctx.obj.service_monitors

--- a/sentry_kube/cli/apply.py
+++ b/sentry_kube/cli/apply.py
@@ -424,6 +424,11 @@ def diff(
     is_flag=True,
     help="Allows regular diff/apply to spawn Jobs",
 )
+@click.option(
+    "--deployment-image",
+    type=str | None,
+    help="Override the deployment image for the services",
+)
 @click.pass_context
 @allow_for_all_services
 def apply(
@@ -438,7 +443,15 @@ def apply(
     skip_monitor_checks: bool,
     soak_only: bool,
     allow_jobs: bool,
+    deployment_image: str | None = None,
 ):
+    if len(services) > 1 and deployment_image:
+        raise click.BadArgumentUsage(
+            "Cannot specify --deployment-image with multiple services"
+        )
+    elif deployment_image:
+        os.environ["DEPLOYMENT_IMAGE"] = deployment_image
+
     customer_name = ctx.obj.customer_name
     service_monitors = ctx.obj.service_monitors
 

--- a/sentry_kube/cli/apply.py
+++ b/sentry_kube/cli/apply.py
@@ -336,6 +336,11 @@ def render(ctx, services, raw, pager, filters, materialize, use_canary: bool):
     is_flag=True,
     help="Allows regular diff/apply to spawn Jobs",
 )
+@click.option(
+    "--deployment-image",
+    type=str,
+    help="Override the deployment image for the services",
+)
 @allow_for_all_services
 def diff(
     ctx,
@@ -345,6 +350,7 @@ def diff(
     important_diffs_only: bool,
     use_canary: bool,
     allow_jobs: bool,
+    deployment_image: str | None = None,
 ):
     """
     Render a diff between production and local configs, using a wrapper around
@@ -353,6 +359,13 @@ def diff(
     This is non-destructive and tells you what would be applied, if
     anything, with your current changes.
     """
+    if len(services) > 1 and deployment_image:
+        raise click.BadArgumentUsage(
+            "Cannot specify --deployment-image with multiple services"
+        )
+    elif deployment_image:
+        os.environ["DEPLOYMENT_IMAGE"] = deployment_image
+
     click.echo(f"Rendering services: {', '.join(services)}")
     skip_kinds = ("Job",) if not allow_jobs else None
     definitions = "".join(


### PR DESCRIPTION
When deploying new things we don't want to query Prod for the image as we don't have anything to query so support passing in an image.