### PR TITLE
fix: Pass back region_name when using alias so lookups always work

### DIFF
--- a/libsentrykube/customer.py
+++ b/libsentrykube/customer.py
@@ -38,7 +38,7 @@ def load_customer_data(
     config: Config, customer_name: str, cluster_name: str
 ) -> Dict[str, Any]:
     try:
-        region_name, region_config = get_region_config(config, customer_name)
+        _, region_config = get_region_config(config, customer_name)
     except ValueError:
         die(
             f"Region '{customer_name}' not found. Did you mean one of: \n\n"
@@ -59,7 +59,7 @@ def load_region_helm_data(
     config: Config, region_name: str, cluster_name: str
 ) -> HelmData:
     try:
-        region_name, region_config = get_region_config(config, region_name)
+        _, region_config = get_region_config(config, region_name)
     except ValueError:
         die(
             f"Region '{region_name}' not found. Did you mean one of: \n\n"

--- a/libsentrykube/customer.py
+++ b/libsentrykube/customer.py
@@ -15,7 +15,7 @@ ALLOYDB_DISCOVERY_SERVICEURL = (
 
 
 @cache
-def get_region_config(config: Config, region_name: str) -> SiloRegion:
+def get_region_config(config: Config, region_name: str) -> tuple[str, SiloRegion]:
     region_config = None
     if region_name in config.silo_regions:
         region_config = config.silo_regions[region_name]
@@ -24,12 +24,13 @@ def get_region_config(config: Config, region_name: str) -> SiloRegion:
         for region in config.silo_regions:
             if region_name in config.silo_regions[region].aliases:
                 region_config = config.silo_regions[region]
+                region_name = region
                 break
 
     if region_config is None:
         raise ValueError(f"Region '{region_name}' not found")
 
-    return region_config
+    return region_name, region_config
 
 
 @cache
@@ -37,7 +38,7 @@ def load_customer_data(
     config: Config, customer_name: str, cluster_name: str
 ) -> Dict[str, Any]:
     try:
-        region_config = get_region_config(config, customer_name)
+        region_name, region_config = get_region_config(config, customer_name)
     except ValueError:
         die(
             f"Region '{customer_name}' not found. Did you mean one of: \n\n"
@@ -58,7 +59,7 @@ def load_region_helm_data(
     config: Config, region_name: str, cluster_name: str
 ) -> HelmData:
     try:
-        region_config = get_region_config(config, region_name)
+        region_name, region_config = get_region_config(config, region_name)
     except ValueError:
         die(
             f"Region '{region_name}' not found. Did you mean one of: \n\n"
@@ -67,7 +68,7 @@ def load_region_helm_data(
 
     k8s_config = region_config.k8s_config
 
-    # If the customer has only one cluster, just use the value from config
+    # If the region has only one cluster, just use the value from config
     cluster_name = k8s_config.cluster_name or cluster_name
 
     cluster = load_cluster_configuration(k8s_config, cluster_name)

--- a/libsentrykube/events.py
+++ b/libsentrykube/events.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 import click
 import httpx
 from libsentrykube.config import Config
+from libsentrykube.customer import get_region_config
 
 DD_API_BASE = "https://api.datadoghq.com"
 
@@ -67,9 +68,9 @@ def _markdown_text(text: str) -> str:
     return f"%%%\n{text}\n%%%"
 
 
-def _get_sentry_region(customer_name: str) -> str:
-    silo_config = Config().silo_regions[customer_name]
-    return silo_config.sentry_region
+def _get_sentry_region(region_name: str) -> str:
+    _, region_config = get_region_config(Config(), region_name)
+    return region_config.sentry_region
 
 
 def report_terragrunt_event(

--- a/sentry_kube/cli/__init__.py
+++ b/sentry_kube/cli/__init__.py
@@ -133,7 +133,7 @@ Valid regions:
             )
 
         try:
-            customer_config = get_region_config(config, customer)
+            customer_name, customer_config = get_region_config(config, customer)
         except ValueError:
             die(
                 f"""Invalid region specified, must be one of:
@@ -142,7 +142,7 @@ Valid regions:
             )
 
         if not quiet:
-            click.echo(f"Operating for customer {customer}.")
+            click.echo(f"Operating for customer {customer_name}.")
 
         cluster_to_load = customer_config.k8s_config.cluster_name or cluster_name
 
@@ -155,7 +155,7 @@ Valid regions:
         if ctx.invoked_subcommand == "ssh":
             ctx.obj = CliContext(
                 context_name=context_name,
-                customer_name=customer,
+                customer_name=customer_name,
                 cluster_name=cluster.name,
                 quiet_mode=quiet,
                 service_monitors={},  # type: ignore
@@ -175,7 +175,7 @@ Valid regions:
 
             ctx.obj = CliContext(
                 context_name=context_name,
-                customer_name=customer,
+                customer_name=customer_name,
                 cluster_name=cluster.name,
                 quiet_mode=quiet,
                 service_monitors=customer_config.service_monitors,
@@ -187,7 +187,7 @@ Valid regions:
 
         ctx.obj = CliContext(
             context_name=context_name,
-            customer_name=customer,
+            customer_name=customer_name,
             cluster_name=cluster.name,
             quiet_mode=quiet,
             cluster=cluster,


### PR DESCRIPTION
When using aliases, we should pass back the proper region name so things like reporting send the actual region and not the alias.