### PR TITLE
fix(debug): Filter duplicated mount paths

### DIFF
--- a/sentry_kube/cli/debug.py
+++ b/sentry_kube/cli/debug.py
@@ -102,12 +102,10 @@ def debug(ctx, container, image, namespace, quiet):
             del vm["subPath"]
             original_mount_path = vm["mountPath"]
             original_mount_dir = "/".join(vm["mountPath"].split("/")[:-1])
-            new_mount_path = f"/subPathMounts{original_mount_dir}"
+            new_mount_path = f"/subPathMounts/{vm['name']}/{original_mount_dir}"
             vm["mountPath"] = new_mount_path
             mount_instructions += f"  mkdir -p {original_mount_dir}\n"
-            mount_instructions += (
-                f"  ln -sf /subPathMounts{original_mount_path} {original_mount_path}\n"
-            )
+            mount_instructions += f"  ln -sf /subPathMounts/{vm['name']}/{original_mount_path} {original_mount_path}\n"
 
     if mount_instructions:
         click.echo("Subpath mounts are not allowed for ephemeral containers.")


### PR DESCRIPTION
Fixes this issue:
```
The Pod "relay-6b7b775cfb-wsh9v" is invalid: spec.ephemeralContainers[4].volumeMounts[2].mountPath:
Invalid value: "/subPathMounts/etc/relay": must be unique
```