### PR TITLE
(fix): add $DEPLOYMENT_IMAGE parsing to statefulset image extension

### DIFF
--- a/libsentrykube/ext.py
+++ b/libsentrykube/ext.py
@@ -157,6 +157,9 @@ class StatefulSetImage(SimpleExtension):
         if os.getenv("KUBERNETES_OFFLINE"):
             return default
 
+        if "DEPLOYMENT_IMAGE" in os.environ:
+            return os.getenv("DEPLOYMENT_IMAGE")
+
         namespace, name = kube_extract_namespace(stateful_set_name)
         client = kube_get_client()
         try:


### PR DESCRIPTION
We can use `--deployment-image` to set the image for deployment resources. We should be able to use this for statefulset image overrides as well.

I don't think it's worth renaming the option, if this causes problems we can revisit.

**Example**

Without:

```
sentry-kube -C s4s2 -q apply taskbroker --bypass-canary
Rendering services: taskbroker
Waiting on kubectl diff.
Nothing to apply.
```

With `--deployment-image`:

```diff
sentry-kube -C s4s2 -q apply taskbroker --bypass-canary --deployment-image us-central1-docker.pkg.dev/sentryio/taskbroker/image:27c622e090db0851c43e3c6e9afbf9ca023358c9
Rendering services: taskbroker
Waiting on kubectl diff.


--- /var/folders/l9/1v11xf0542jc39nkhycww32c0000gn/T/LIVE-577280063/apps.v1.StatefulSet.default.task-cutover-broker     2025-08-13 09:50:56
+++ /var/folders/l9/1v11xf0542jc39nkhycww32c0000gn/T/MERGED-801113461/apps.v1.StatefulSet.default.task-cutover-broker   2025-08-13 09:50:56
@@ -5,7 +5,7 @@
   creationTimestamp: "2025-08-13T13:41:49Z"
-  generation: 1
+  generation: 2
   labels:
     env: primary
     service: taskbroker
@@ -124,7 +124,7 @@
           value: "2000000000"
         - name: TASKBROKER_FULL_VACUUM_ON_START
           value: "true"
-        image: us-central1-docker.pkg.dev/sentryio/taskbroker/image:_TAG_DOES_NOT_EXIST
+        image: us-central1-docker.pkg.dev/sentryio/taskbroker/image:27c622e090db0851c43e3c6e9afbf9ca023358c9
         imagePullPolicy: IfNotPresent
         name: taskbroker
         ports:


--- /var/folders/l9/1v11xf0542jc39nkhycww32c0000gn/T/LIVE-577280063/apps.v1.StatefulSet.default.task-default-broker     2025-08-13 09:50:54
+++ /var/folders/l9/1v11xf0542jc39nkhycww32c0000gn/T/MERGED-801113461/apps.v1.StatefulSet.default.task-default-broker   2025-08-13 09:50:54
@@ -5,7 +5,7 @@
   creationTimestamp: "2025-08-13T13:41:48Z"
-  generation: 1
+  generation: 2
   labels:
     env: primary
     service: taskbroker
@@ -124,7 +124,7 @@
           value: "2000000000"
         - name: TASKBROKER_FULL_VACUUM_ON_START
           value: "true"
-        image: us-central1-docker.pkg.dev/sentryio/taskbroker/image:_TAG_DOES_NOT_EXIST
+        image: us-central1-docker.pkg.dev/sentryio/taskbroker/image:27c622e090db0851c43e3c6e9afbf9ca023358c9
         imagePullPolicy: IfNotPresent
         name: taskbroker
         ports:


--- /var/folders/l9/1v11xf0542jc39nkhycww32c0000gn/T/LIVE-577280063/apps.v1.StatefulSet.default.task-ingest-broker      2025-08-13 09:50:54
+++ /var/folders/l9/1v11xf0542jc39nkhycww32c0000gn/T/MERGED-801113461/apps.v1.StatefulSet.default.task-ingest-broker    2025-08-13 09:50:54
@@ -5,7 +5,7 @@
   creationTimestamp: "2025-08-13T13:41:50Z"
-  generation: 1
+  generation: 2
   labels:
     env: primary
     service: taskbroker
@@ -124,7 +124,7 @@
           value: "2000000000"
         - name: TASKBROKER_FULL_VACUUM_ON_START
           value: "true"
-        image: us-central1-docker.pkg.dev/sentryio/taskbroker/image:_TAG_DOES_NOT_EXIST
+        image: us-central1-docker.pkg.dev/sentryio/taskbroker/image:27c622e090db0851c43e3c6e9afbf9ca023358c9
         imagePullPolicy: IfNotPresent
         name: taskbroker
         ports:


--- /var/folders/l9/1v11xf0542jc39nkhycww32c0000gn/T/LIVE-577280063/apps.v1.StatefulSet.default.task-ingest-broker-canary       2025-08-13 09:50:56
+++ /var/folders/l9/1v11xf0542jc39nkhycww32c0000gn/T/MERGED-801113461/apps.v1.StatefulSet.default.task-ingest-broker-canary     2025-08-13 09:50:56
@@ -5,7 +5,7 @@
   creationTimestamp: "2025-08-13T13:41:50Z"
-  generation: 1
+  generation: 2
   labels:
     env: canary
     service: taskbroker
@@ -124,7 +124,7 @@
           value: "2000000000"
         - name: TASKBROKER_FULL_VACUUM_ON_START
           value: "true"
-        image: us-central1-docker.pkg.dev/sentryio/taskbroker/image:_TAG_DOES_NOT_EXIST
+        image: us-central1-docker.pkg.dev/sentryio/taskbroker/image:27c622e090db0851c43e3c6e9afbf9ca023358c9
         imagePullPolicy: IfNotPresent
         name: taskbroker
         ports:

Are you sure you want to apply this for region s4s2, cluster default? [y/N]: N
Aborted!
```