### PR TITLE
fix loading values with values_of helper when external=True

### DIFF
--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -147,7 +147,6 @@ def _consolidate_variables(
           patch the regional override preserving comments.
     """
 
-    click.echo(f"consolidate: {service_name}", err=True)
     if external:
         service_path = workspace_root() / service_name
     else:


### PR DESCRIPTION
When using the `values_of()` helper with `external=True`, we need to adjust the path to be relative to the workspace root in order to load the merge config.