### PR TITLE
fix(diff): Allow drift detection to force diff to exit 0

### DIFF
--- a/sentry_kube/cli/apply.py
+++ b/sentry_kube/cli/apply.py
@@ -360,6 +360,7 @@ def diff(
     use_canary: bool,
     allow_jobs: bool,
     deployment_image: str | None = None,
+    always_exit_with_zero: bool = False,
 ):
     """
     Render a diff between production and local configs, using a wrapper around
@@ -388,14 +389,16 @@ def diff(
             fg="red",
         )
 
-    ctx.exit(
-        _diff_kubectl(
-            ctx=ctx,
-            definitions=definitions,
-            server_side=server_side,
-            important_diffs_only=important_diffs_only,
-        )
+    diff_ret = _diff_kubectl(
+        ctx=ctx,
+        definitions=definitions,
+        server_side=server_side,
+        important_diffs_only=important_diffs_only,
     )
+
+    ret = 0 if always_exit_with_zero else diff_ret
+
+    ctx.exit(ret)
 
 
 @click.command()

--- a/sentry_kube/cli/detect_drift.py
+++ b/sentry_kube/cli/detect_drift.py
@@ -32,7 +32,12 @@ def detect_drift(ctx, issue):
     for service in services:
         output = None
         try:
-            output = ctx.invoke(diff, services=[service], important_diffs_only=True)
+            output = ctx.invoke(
+                diff,
+                services=[service],
+                important_diffs_only=True,
+                always_exit_with_zero=True,
+            )
         except TemplateError as e:
             click.secho(e, fg="red")
             if issue:


### PR DESCRIPTION
https://github.com/getsentry/sentry-infra-tools/pull/150 updated `diff` so we can support exit 1 on diff as a precursor to use in GoCD, but this unfortunately causes `detect-drift` to exit early.  This PR allows `detect-drift` to force an exit 0 so it can successfully complete.