### PR TITLE
fix(detect-drift): Don't exit when running diff from detect-drift

### DIFF
--- a/sentry_kube/cli/apply.py
+++ b/sentry_kube/cli/apply.py
@@ -360,7 +360,7 @@ def diff(
     use_canary: bool,
     allow_jobs: bool,
     deployment_image: str | None = None,
-    always_exit_with_zero: bool = False,
+    exit_with_result: bool = True,
 ):
     """
     Render a diff between production and local configs, using a wrapper around
@@ -389,16 +389,15 @@ def diff(
             fg="red",
         )
 
-    diff_ret = _diff_kubectl(
-        ctx=ctx,
-        definitions=definitions,
-        server_side=server_side,
-        important_diffs_only=important_diffs_only,
-    )
-
-    ret = 0 if always_exit_with_zero else diff_ret
-
-    ctx.exit(ret)
+    if exit_with_result:
+        ctx.exit(
+            _diff_kubectl(
+                ctx=ctx,
+                definitions=definitions,
+                server_side=server_side,
+                important_diffs_only=important_diffs_only,
+            )
+        )
 
 
 @click.command()

--- a/sentry_kube/cli/detect_drift.py
+++ b/sentry_kube/cli/detect_drift.py
@@ -36,7 +36,7 @@ def detect_drift(ctx, issue):
                 diff,
                 services=[service],
                 important_diffs_only=True,
-                always_exit_with_zero=True,
+                exit_with_result=False,
             )
         except TemplateError as e:
             click.secho(e, fg="red")


### PR DESCRIPTION
https://github.com/getsentry/sentry-infra-tools/pull/158 was a bad fix for detect-drift, we didn't want to exit 0 but instead don't want to exit at all from that command.