### PR TITLE
chore: Update default ST deployment

### DIFF
--- a/sentry_kube/cli/run_pod.py
+++ b/sentry_kube/cli/run_pod.py
@@ -215,7 +215,7 @@ def run_pod(
     else:
         default_service, default_deployment = (
             "getsentry",
-            "worker-save",
+            "web",
         )
 
     if service == _DEFAULT_STR:


### PR DESCRIPTION
We don't run celery works anymore, update the default deployment to use the `web` deployment