### PR TITLE
(fix): add context after cmd

### DIFF
--- a/sentry_kube/cli/kubectl.py
+++ b/sentry_kube/cli/kubectl.py
@@ -29,11 +29,12 @@ def kubectl(ctx, quiet, yes):
     quiet = ctx.obj.quiet_mode or quiet
 
     cmd = [f"{ensure_kubectl()}"]
+
+    cmd += list(args)
+
     # todo untested
     if not should_run_with_empty_context():
         cmd += ["--context", context]
-
-    cmd += list(args)
 
     if not quiet:
         click.echo(


### PR DESCRIPTION
Otherwise plugins error with "Error: flags cannot be placed before plugin name: --context"