### PR TITLE
Prevents --context from falling after the "--".

### DIFF
--- a/sentry_kube/cli/kubectl.py
+++ b/sentry_kube/cli/kubectl.py
@@ -34,7 +34,12 @@ def kubectl(ctx, quiet, yes):
 
     # todo untested
     if not should_run_with_empty_context():
-        cmd += ["--context", context]
+        context_flag = ["--context", context]
+        try:
+            index = cmd.index("--")
+            cmd[index:index] = context_flag
+        except ValueError:
+            cmd += context_flag
 
     if not quiet:
         click.echo(


### PR DESCRIPTION
Moving context to the end fails with commands that construct an arg list with "--" in it (including run-pod and exec). "--" indicates the end of arguments, and causes the context flag to not be accepted by kubectl. This PR checks if there is a "--" and if so, puts the context flag immediately before it.