### PR TITLE
fix: add sorting logic to fix over-materialization

### DIFF
--- a/libsentrykube/kube.py
+++ b/libsentrykube/kube.py
@@ -394,6 +394,7 @@ def materialize(
         if split_by_kind:
             for doc in yamldoc:
                 namespace = doc.get("metadata", {}).get("namespace", "default")
+                # Naming standard is namespace-kind-name as name is not required to be unique across namespaces/kinds.
                 with open(
                     output_path
                     / f"{namespace}-{doc['kind'].lower()}-{doc['metadata']['name'].lower()}.yaml",


### PR DESCRIPTION
existing_content and rendered_services were sorted differently which resulted in materialization triggering when it didn't need to, this adds sorting of the data to make the diffs comparable.