### PR TITLE
Fix issue with Helm 4 where KubeVersion is not pulled in

### DIFF
--- a/libsentrykube/helm.py
+++ b/libsentrykube/helm.py
@@ -621,6 +621,7 @@ def diff(
             "--namespace",
             helm_release.namespace,
             "--install",
+            "--dry-run=server",
         ]
         if kctx:
             helm_params.extend(["--kube-context", kctx])


### PR DESCRIPTION
With Helm 4, KubeVersion is not being pulled in properly when running `helm diff`. This results in Helm using the default value of 1.20.0, which does not meet the minimum version specified in many charts, causing the diff to fail.

Hypothetically this PR (https://github.com/databus23/helm-diff/pull/872) should have fixed this, but it doesn't seem to work. Adding this flag makes it work for Helm 3 and Helm 4.