### PR TITLE
chore: Don't enforce stage match for non-CI work

### DIFF
--- a/sentry_kube/cli/__init__.py
+++ b/sentry_kube/cli/__init__.py
@@ -153,15 +153,6 @@ Valid regions for stage '{stage}':
 """
             )
 
-        if customer_config.stage != stage:
-            die(
-                f"""Region '{customer_name}' has stage '{customer_config.stage}', not '{stage}'.
-
-Valid regions for stage '{stage}':
-{newline_customers}
-"""
-            )
-
         if not quiet:
             click.echo(f"Operating for customer {customer_name}.")
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-infra-tools/pull/206 Added logic to better exclude regions being built from CI, it also included checks for CLI apply, render, etc which is annoying to always have to type.  Ignoring the stage here doesn't impact CI so let's remove it