### PR TITLE
fix(debug): Pass namespace to kubectl command

### DIFF
--- a/sentry_kube/cli/debug.py
+++ b/sentry_kube/cli/debug.py
@@ -82,6 +82,7 @@ def debug(ctx, container, image, namespace, privileged, quiet):
     cmd += [
         "debug",
         "-it",
+        f"--namespace={namespace}",
         f"--image={image}",
         f"--target={container}",
         f"--custom={tmp.name}",


### PR DESCRIPTION
Couldn't test this yet (no perms), seems right to me, but if you can do a quick test (Gio/Alex) first that'd be great.