### PR TITLE
Adds more custom types to be excluded in run-job.

### DIFF
--- a/sentry_kube/cli/run_job.py
+++ b/sentry_kube/cli/run_job.py
@@ -44,7 +44,13 @@ def run_job(ctx, job_name, arg, kwarg, service_name, yes, quiet):
             cluster_name,
             # Skip GKE CRDs which don't work with our
             # client-side kubernetes API management
-            skip_kinds=("BackendConfig", "ManagedCertificate", "VerticalPodAutoscaler"),
+            skip_kinds=(
+                "BackendConfig",
+                "ManagedCertificate",
+                "VerticalPodAutoscaler",
+                "SecretProviderClass",
+                "SecretSync",
+            ),
             kind_matches=("Job",),
             name_matches=(job_name,),
             extra_args=arg,


### PR DESCRIPTION
This is a quick fix, probably needs a bit of a different way to do this. Maybe excluding based on group?