### PR TITLE
fix: Make render_services exit non-zero on materialization failures

### DIFF
--- a/sentry_kube/render_services.py
+++ b/sentry_kube/render_services.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import traceback
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 from typing import Sequence
@@ -31,7 +32,7 @@ def _materialize_service_worker(
 
 def _render_multithreaded(
     resources_to_render, split_by_kind: bool, workers: int
-) -> bool:
+) -> tuple[bool, list[tuple[str, str, str, Exception]]]:
     work_items = []
     for resource in resources_to_render:
         logger.debug(
@@ -54,31 +55,48 @@ def _render_multithreaded(
             )
 
     changes_made = False
+    errors: list[tuple[str, str, str, Exception]] = []
+    future_to_work = {}
     with ProcessPoolExecutor(max_workers=workers) as executor:
-        futures = [
-            executor.submit(
+        for customer_name, service_name, cluster_name in work_items:
+            future = executor.submit(
                 _materialize_service_worker,
                 customer_name,
                 service_name,
                 cluster_name,
                 split_by_kind,
             )
-            for customer_name, service_name, cluster_name in work_items
-        ]
+            future_to_work[future] = (customer_name, service_name, cluster_name)
 
-        for future in as_completed(futures):
-            customer_name, cluster_name, service_name, changed = future.result()
+        for future in as_completed(future_to_work):
+            cust, svc, clust = future_to_work[future]
+            try:
+                _, _, _, changed = future.result()
+            except Exception as exc:
+                errors.append((cust, clust, svc, exc))
+                click.echo(
+                    f"Service FAILED: {cust} : {clust} : {svc} — {type(exc).__name__}: {exc}",
+                    err=True,
+                )
+                logger.debug(
+                    f"Traceback for {cust} : {clust} : {svc}:\n{traceback.format_exc()}"
+                )
+                continue
             if changed:
                 changes_made = True
-                click.echo(
-                    f"Service materialized: {customer_name} : {cluster_name} : {service_name}"
-                )
+                click.echo(f"Service materialized: {cust} : {clust} : {svc}")
             else:
-                click.echo(
-                    f"Service unchanged: {customer_name} : {cluster_name} : {service_name}"
-                )
+                click.echo(f"Service unchanged: {cust} : {clust} : {svc}")
 
-    return changes_made
+    if errors:
+        click.echo(
+            f"\n{len(errors)} service(s) failed to render:",
+            err=True,
+        )
+        for cust, clust, svc, err in errors:
+            click.echo(f"  - {cust} : {clust} : {svc} — {err}", err=True)
+
+    return changes_made, errors
 
 
 @click.command()
@@ -143,9 +161,12 @@ def render_services(
     changes_made = False
 
     if multithreaded:
-        changes_made = _render_multithreaded(
+        changes_made, errors = _render_multithreaded(
             resources_to_render, split_by_kind, workers
         )
+
+        if errors:
+            raise SystemExit(1)
 
         if changes_made:
             click.echo(
@@ -153,6 +174,7 @@ def render_services(
             )
             exit(-1)
     else:
+        errors = []
         for resource in resources_to_render:
             logger.debug(
                 f"Initializing cluster context for {resource.customer_name} : {resource.cluster_name}"
@@ -170,21 +192,39 @@ def render_services(
 
             for s in services_to_materialize:
                 logger.debug(f"Materializing service: {s}")
-                changed = materialize(
-                    customer_name=resource.customer_name,
-                    service_name=s,
-                    cluster_name=resource.cluster_name,
-                    split_by_kind=split_by_kind,
-                )
+                cust = resource.customer_name
+                clust = resource.cluster_name
+                try:
+                    changed = materialize(
+                        customer_name=cust,
+                        service_name=s,
+                        cluster_name=clust,
+                        split_by_kind=split_by_kind,
+                    )
+                except Exception as exc:
+                    errors.append((cust, clust, s, exc))
+                    click.echo(
+                        f"Service FAILED: {cust} : {clust} : {s} — {type(exc).__name__}: {exc}",
+                        err=True,
+                    )
+                    logger.debug(
+                        f"Traceback for {cust} : {clust} : {s}:\n{traceback.format_exc()}"
+                    )
+                    continue
                 if changed:
                     changes_made = True
-                    click.echo(
-                        f"Service materialized: {resource.customer_name} : {resource.cluster_name} : {s}"
-                    )
+                    click.echo(f"Service materialized: {cust} : {clust} : {s}")
                 else:
-                    click.echo(
-                        f"Service unchanged: {resource.customer_name} : {resource.cluster_name} : {s}"
-                    )
+                    click.echo(f"Service unchanged: {cust} : {clust} : {s}")
+
+        if errors:
+            click.echo(
+                f"\n{len(errors)} service(s) failed to render:",
+                err=True,
+            )
+            for cust, clust, svc, err in errors:
+                click.echo(f"  - {cust} : {clust} : {svc} — {err}", err=True)
+            raise SystemExit(1)
 
         if changes_made:
             click.echo(

--- a/sentry_kube/tests/test_render_services.py
+++ b/sentry_kube/tests/test_render_services.py
@@ -1,0 +1,224 @@
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+from click.testing import CliRunner
+from jinja2.exceptions import UndefinedError
+
+from libsentrykube.reversemap import ResourceReference
+from sentry_kube.render_services import _render_multithreaded, render_services
+
+
+def _make_resource(customer, cluster, service=None):
+    return ResourceReference(
+        customer_name=customer,
+        cluster_name=cluster,
+        service_name=service,
+    )
+
+
+class TestRenderMultithreaded:
+    """Tests for _render_multithreaded.
+
+    ProcessPoolExecutor is replaced with ThreadPoolExecutor so that
+    mocked callables don't need to survive pickling across processes.
+    """
+
+    @patch("sentry_kube.render_services.ProcessPoolExecutor", ThreadPoolExecutor)
+    @patch("sentry_kube.render_services.init_cluster_context")
+    @patch("sentry_kube.render_services._materialize_service_worker")
+    def test_all_succeed(self, mock_worker, mock_init_ctx):
+        mock_worker.side_effect = [
+            ("cust1", "cluster-a", "svc-a", False),
+            ("cust1", "cluster-a", "svc-b", True),
+        ]
+
+        resources = [
+            _make_resource("cust1", "cluster-a", "svc-a"),
+            _make_resource("cust1", "cluster-a", "svc-b"),
+        ]
+
+        changes_made, errors = _render_multithreaded(
+            resources, split_by_kind=False, workers=1
+        )
+
+        assert errors == []
+        assert changes_made is True
+
+    @patch("sentry_kube.render_services.ProcessPoolExecutor", ThreadPoolExecutor)
+    @patch("sentry_kube.render_services.init_cluster_context")
+    @patch("sentry_kube.render_services._materialize_service_worker")
+    def test_no_changes(self, mock_worker, mock_init_ctx):
+        mock_worker.return_value = ("cust1", "cluster-a", "svc-a", False)
+
+        resources = [_make_resource("cust1", "cluster-a", "svc-a")]
+
+        changes_made, errors = _render_multithreaded(
+            resources, split_by_kind=False, workers=1
+        )
+
+        assert errors == []
+        assert changes_made is False
+
+    @patch("sentry_kube.render_services.ProcessPoolExecutor", ThreadPoolExecutor)
+    @patch("sentry_kube.render_services.init_cluster_context")
+    @patch("sentry_kube.render_services._materialize_service_worker")
+    def test_partial_failure_collects_errors(self, mock_worker, mock_init_ctx):
+        error = UndefinedError("'dict object' has no attribute 'missing_var'")
+        mock_worker.side_effect = [
+            ("cust1", "cluster-a", "svc-ok", False),
+            error,
+        ]
+
+        resources = [
+            _make_resource("cust1", "cluster-a", "svc-ok"),
+            _make_resource("cust1", "cluster-a", "svc-bad"),
+        ]
+
+        changes_made, errors = _render_multithreaded(
+            resources, split_by_kind=False, workers=1
+        )
+
+        assert len(errors) == 1
+        _, _, svc, exc = errors[0]
+        assert svc == "svc-bad"
+        assert isinstance(exc, UndefinedError)
+        assert changes_made is False
+
+    @patch("sentry_kube.render_services.ProcessPoolExecutor", ThreadPoolExecutor)
+    @patch("sentry_kube.render_services.init_cluster_context")
+    @patch("sentry_kube.render_services._materialize_service_worker")
+    def test_all_fail(self, mock_worker, mock_init_ctx):
+        mock_worker.side_effect = [
+            RuntimeError("boom1"),
+            RuntimeError("boom2"),
+        ]
+
+        resources = [
+            _make_resource("cust1", "cluster-a", "svc-a"),
+            _make_resource("cust2", "cluster-b", "svc-b"),
+        ]
+
+        changes_made, errors = _render_multithreaded(
+            resources, split_by_kind=False, workers=1
+        )
+
+        assert len(errors) == 2
+        assert changes_made is False
+
+    @patch("sentry_kube.render_services.ProcessPoolExecutor", ThreadPoolExecutor)
+    @patch("sentry_kube.render_services.init_cluster_context")
+    @patch("sentry_kube.render_services._materialize_service_worker")
+    def test_error_summary_output(self, mock_worker, mock_init_ctx, capsys):
+        mock_worker.side_effect = [
+            UndefinedError("missing_var"),
+            ("cust1", "cluster-a", "svc-ok", False),
+        ]
+
+        resources = [
+            _make_resource("cust1", "cluster-a", "svc-bad"),
+            _make_resource("cust1", "cluster-a", "svc-ok"),
+        ]
+
+        _render_multithreaded(resources, split_by_kind=False, workers=1)
+
+        captured = capsys.readouterr()
+        assert "1 service(s) failed to render:" in captured.err
+        assert "svc-bad" in captured.err
+        assert "Service FAILED:" in captured.err
+
+
+class TestRenderServicesCLI:
+    @patch("sentry_kube.render_services.extract_clusters")
+    @patch("sentry_kube.render_services.build_index")
+    @patch("sentry_kube.render_services.init_cluster_context")
+    @patch("sentry_kube.render_services.materialize")
+    def test_single_threaded_success_exits_zero(
+        self, mock_materialize, mock_init_ctx, mock_build_index, mock_extract
+    ):
+        mock_materialize.return_value = False
+        mock_extract.return_value = [
+            _make_resource("cust1", "cluster-a", "svc-a"),
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(render_services, ["some-file"])
+
+        assert result.exit_code == 0
+
+    @patch("sentry_kube.render_services.extract_clusters")
+    @patch("sentry_kube.render_services.build_index")
+    @patch("sentry_kube.render_services.init_cluster_context")
+    @patch("sentry_kube.render_services.materialize")
+    def test_single_threaded_failure_exits_nonzero(
+        self, mock_materialize, mock_init_ctx, mock_build_index, mock_extract
+    ):
+        mock_materialize.side_effect = UndefinedError("missing_var")
+        mock_extract.return_value = [
+            _make_resource("cust1", "cluster-a", "svc-a"),
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(render_services, ["some-file"])
+
+        assert result.exit_code == 1
+        assert "1 service(s) failed to render:" in result.output
+        assert "svc-a" in result.output
+
+    @patch("sentry_kube.render_services.extract_clusters")
+    @patch("sentry_kube.render_services.build_index")
+    @patch("sentry_kube.render_services.init_cluster_context")
+    @patch("sentry_kube.render_services.materialize")
+    def test_single_threaded_partial_failure_processes_all(
+        self, mock_materialize, mock_init_ctx, mock_build_index, mock_extract
+    ):
+        mock_materialize.side_effect = [
+            False,
+            UndefinedError("missing_var"),
+            False,
+        ]
+        mock_extract.return_value = [
+            _make_resource("cust1", "cluster-a", "svc-ok1"),
+            _make_resource("cust1", "cluster-a", "svc-bad"),
+            _make_resource("cust1", "cluster-a", "svc-ok2"),
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(render_services, ["some-file"])
+
+        assert result.exit_code == 1
+        assert "Service unchanged: cust1 : cluster-a : svc-ok1" in result.output
+        assert "Service unchanged: cust1 : cluster-a : svc-ok2" in result.output
+        assert "1 service(s) failed to render:" in result.output
+
+    @patch("sentry_kube.render_services._render_multithreaded")
+    @patch("sentry_kube.render_services.extract_clusters")
+    @patch("sentry_kube.render_services.build_index")
+    def test_multithreaded_failure_exits_nonzero(
+        self, mock_build_index, mock_extract, mock_render_mt
+    ):
+        mock_extract.return_value = [
+            _make_resource("cust1", "cluster-a", "svc-a"),
+        ]
+        error = UndefinedError("missing_var")
+        mock_render_mt.return_value = (False, [("cust1", "cluster-a", "svc-a", error)])
+
+        runner = CliRunner()
+        result = runner.invoke(render_services, ["--multithreaded", "some-file"])
+
+        assert result.exit_code == 1
+
+    @patch("sentry_kube.render_services._render_multithreaded")
+    @patch("sentry_kube.render_services.extract_clusters")
+    @patch("sentry_kube.render_services.build_index")
+    def test_multithreaded_success_exits_zero(
+        self, mock_build_index, mock_extract, mock_render_mt
+    ):
+        mock_extract.return_value = [
+            _make_resource("cust1", "cluster-a", "svc-a"),
+        ]
+        mock_render_mt.return_value = (False, [])
+
+        runner = CliRunner()
+        result = runner.invoke(render_services, ["--multithreaded", "some-file"])
+
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- When a service fails to render (e.g. `jinja2.exceptions.UndefinedError`), the process now collects all errors, continues processing remaining services, prints a clear summary, and exits with code 1
- Previously the `--multithreaded` path would crash on the first failing future (hiding subsequent failures), and the non-multithreaded path had no error handling at all
- Full tracebacks are available via `--debug` and include customer/cluster/service context

## Example output
```
Service FAILED: customer1 : cluster-a : getsentry — UndefinedError: 'dict object' has no attribute 'some_var'
Service unchanged: customer2 : cluster-a : common
...

4 service(s) failed to render:
  - customer1 : cluster-a : getsentry — 'dict object' has no attribute 'some_var'
  - customer1 : cluster-b : getsentry — 'dict object' has no attribute 'some_var'
  - customer2 : cluster-a : getsentry — 'dict object' has no attribute 'some_var'
  - customer2 : cluster-b : getsentry — 'dict object' has no attribute 'some_var'
make: *** [materialize-k8s] Error 1
```

## Test plan
- [x] Reproduced locally with `make materialize-k8s` — 4 failing services now show clear error lines and the process exits non-zero
- [ ] CI should now fail on render errors instead of reporting success

Made with [Cursor](https://cursor.com)