### PR TITLE
feat(pr-approver): Auto-approve data_disk_size increases

### DIFF
--- a/pr_approver/rules.py
+++ b/pr_approver/rules.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Callable, Iterable
 from functools import reduce
 from enum import Enum
@@ -79,3 +80,44 @@ def assess_service_registry_change(
             return ApprovalDecision.DECLINE
 
     return ApprovalDecision.APPROVE
+
+
+DATA_DISK_SIZE_LINE = re.compile(r"^(?P<indent>\s*)data_disk_size\s*=\s*(?P<value>\d+)\s*$")
+
+
+def assess_data_disk_size_increase(
+    file_path: Path, base: Path, pr: Path
+) -> ApprovalDecision:
+    """
+    Approve terragrunt HCL changes that consist exclusively of strict
+    increases to ``data_disk_size`` values. Any other modification,
+    file creation, deletion, or a decrease in disk size requires
+    manual review.
+    """
+    base_file = base / file_path
+    pr_file = pr / file_path
+    if not base_file.exists() or not pr_file.exists():
+        return ApprovalDecision.DECLINE
+
+    base_lines = base_file.read_text().splitlines()
+    pr_lines = pr_file.read_text().splitlines()
+    if len(base_lines) != len(pr_lines):
+        return ApprovalDecision.DECLINE
+
+    saw_increase = False
+    for base_line, pr_line in zip(base_lines, pr_lines):
+        if base_line == pr_line:
+            continue
+
+        base_match = DATA_DISK_SIZE_LINE.match(base_line)
+        pr_match = DATA_DISK_SIZE_LINE.match(pr_line)
+        if not base_match or not pr_match:
+            return ApprovalDecision.DECLINE
+        if base_match.group("indent") != pr_match.group("indent"):
+            return ApprovalDecision.DECLINE
+        if int(pr_match.group("value")) <= int(base_match.group("value")):
+            return ApprovalDecision.DECLINE
+
+        saw_increase = True
+
+    return ApprovalDecision.APPROVE if saw_increase else ApprovalDecision.IGNORE

--- a/pr_approver/test_rules.py
+++ b/pr_approver/test_rules.py
@@ -1,5 +1,9 @@
 import pytest
-from pr_approver.rules import ApprovalDecision, assess_service_registry_change
+from pr_approver.rules import (
+    ApprovalDecision,
+    assess_data_disk_size_increase,
+    assess_service_registry_change,
+)
 from typing import Mapping, Any
 import tempfile
 from pathlib import Path
@@ -222,6 +226,109 @@ def test_approval(
                 Path("service.yaml"),
                 Path(temp_dir) / "base",
                 Path(temp_dir) / "pr",
+            )
+            == expected_result
+        )
+
+
+DISK_INCREASE_BASE = """inputs = {
+  data_disk_size = 600
+}
+"""
+
+DISK_INCREASE_PR = """inputs = {
+  data_disk_size = 1200
+}
+"""
+
+DISK_DECREASE_PR = """inputs = {
+  data_disk_size = 300
+}
+"""
+
+DISK_PLUS_OTHER_CHANGE_PR = """inputs = {
+  data_disk_size = 1200
+  machine_type   = "n2-standard-8"
+}
+"""
+
+DISK_PLUS_UNRELATED_LINE_CHANGE_PR = """inputs = {
+  data_disk_size = 1200
+  num_replicas   = 5
+}
+"""
+
+DISK_INCREASE_TESTS = [
+    pytest.param(
+        DISK_INCREASE_BASE,
+        DISK_INCREASE_PR,
+        ApprovalDecision.APPROVE,
+        id="Increasing data_disk_size is approved",
+    ),
+    pytest.param(
+        DISK_INCREASE_BASE,
+        DISK_INCREASE_BASE,
+        ApprovalDecision.IGNORE,
+        id="No-op diff is ignored",
+    ),
+    pytest.param(
+        DISK_INCREASE_BASE,
+        DISK_DECREASE_PR,
+        ApprovalDecision.DECLINE,
+        id="Decreasing data_disk_size requires review",
+    ),
+    pytest.param(
+        DISK_INCREASE_BASE,
+        DISK_PLUS_OTHER_CHANGE_PR,
+        ApprovalDecision.DECLINE,
+        id="Adding unrelated lines requires review",
+    ),
+    pytest.param(
+        "inputs = {\n  data_disk_size = 600\n  num_replicas   = 3\n}\n",
+        DISK_PLUS_UNRELATED_LINE_CHANGE_PR,
+        ApprovalDecision.DECLINE,
+        id="Modifying another line in the same diff requires review",
+    ),
+    pytest.param(
+        None,
+        DISK_INCREASE_PR,
+        ApprovalDecision.DECLINE,
+        id="Adding a new file requires review",
+    ),
+    pytest.param(
+        DISK_INCREASE_BASE,
+        None,
+        ApprovalDecision.DECLINE,
+        id="Deleting a file requires review",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "base, pr, expected_result",
+    DISK_INCREASE_TESTS,
+)
+def test_data_disk_size_increase(
+    base: str | None,
+    pr: str | None,
+    expected_result: ApprovalDecision,
+) -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        base_dir = Path(temp_dir) / "base"
+        os.makedirs(base_dir)
+        pr_dir = Path(temp_dir) / "pr"
+        os.makedirs(pr_dir)
+
+        if base is not None:
+            (base_dir / "local.hcl").write_text(base)
+        if pr is not None:
+            (pr_dir / "local.hcl").write_text(pr)
+
+        assert (
+            assess_data_disk_size_increase(
+                Path("local.hcl"),
+                base_dir,
+                pr_dir,
             )
             == expected_result
         )


### PR DESCRIPTION
Adds `rules.assess_data_disk_size_increase`, an HCL-aware approval rule that approves PRs whose diff to a file consists exclusively of strict increases to `data_disk_size` values. Any other modification, file creation, deletion, or a decrease falls back to manual review.

The rule is intended for terragrunt `local.hcl` files in `getsentry/ops` — disk bumps on ClickHouse clusters are routine and currently block on human review for no real reason.

**Conservative diff matching**

The rule rejects anything it does not understand. It requires the file to exist on both sides, the line count to match, and every changed line to match `data_disk_size = <int>` on both base and PR with the same indentation. This avoids approving reformatting, key renames, or whitespace games.


Agent transcript: https://claudescope.sentry.dev/share/G_YtmygHzuolj1xwrxdwvvlfTSTvDhc45KAenzafbCQ