### PR TITLE
ref: Remove XDS envoy extensions

### DIFF
--- a/libsentrykube/ext.py
+++ b/libsentrykube/ext.py
@@ -480,26 +480,6 @@ class SysctlInitContainer(SimpleExtension):
         )
 
 
-class XDSEDSClusterConfig(SimpleExtension):
-    """
-    Generate the XDS EDS config for use in an envoy cluster definition.
-    """
-
-    def run(self, service_name: str, refresh_delay: str = "1s") -> str:
-        return json.dumps(
-            {
-                "service_name": service_name,
-                "eds_config": {
-                    "api_config_source": {
-                        "api_type": "REST",
-                        "cluster_names": ["xds_cluster"],
-                        "refresh_delay": refresh_delay,
-                    },
-                },
-            }
-        )
-
-
 class RaiseExtension(SimpleExtension):
     """
     Raise a custorm exception from Jinja template

--- a/libsentrykube/setup.py
+++ b/libsentrykube/setup.py
@@ -17,7 +17,6 @@ default_macros = [
     "serviceaccount=libsentrykube.ext:ServiceAccount",
     "deep_merge=libsentrykube.ext:DeepMerge",
     "sysctl_initcontainer=libsentrykube.ext:SysctlInitContainer",
-    "xds_eds_cluster_config=libsentrykube.ext:XDSEDSClusterConfig",
     "get_var=libsentrykube.ext:GetVar",
     "render_external=libsentrykube.ext:RenderExternal",
 ]

--- a/sentry_kube/ext.py
+++ b/sentry_kube/ext.py
@@ -1,9 +1,7 @@
 import json
-from pathlib import Path
-from typing import Any, List, Literal, Mapping, Optional
+from typing import Literal, Mapping
 
-from jinja2 import FileSystemLoader, pass_context
-from yaml import safe_dump_all, safe_load_all
+from yaml import safe_dump_all
 
 from libsentrykube.ext import SimpleExtension
 
@@ -72,80 +70,3 @@ class IAPService(SimpleExtension):
         }
 
         return safe_dump_all([service, backend_config, managed_certificate])
-
-
-class XDSConfigMapFrom(SimpleExtension):
-    @pass_context
-    def run(self, context, path: str, files: Optional[List[str]]) -> str:
-        listeners: list[Any] = []
-        clusters: list[Any] = []
-        assignments: dict[str, Any] = {"by-cluster": {}, "by-node-id": {}}
-        if not files:
-            return safe_dump_all(
-                [
-                    {
-                        "apiVersion": "v1",
-                        "kind": "ConfigMap",
-                        "metadata": {
-                            "name": "xds",
-                            "namespace": "sentry-system",
-                        },
-                        "data": {
-                            "listeners": safe_dump_all([listeners]),
-                            "clusters": safe_dump_all([clusters]),
-                            "assignments": safe_dump_all([assignments]),
-                        },
-                    }
-                ]
-            )
-
-        types = "listeners", "clusters"
-        env_loader = self.environment.loader
-        assert isinstance(env_loader, FileSystemLoader)
-        for searchpath in env_loader.searchpath:
-            prefix = len(searchpath) + 1
-            for f in files:
-                for p in Path(searchpath).glob(f"{path}/{f}.yaml"):
-                    for doc in safe_load_all(
-                        self.environment.get_template(str(p)[prefix:])
-                        .render(context)
-                        .encode("utf-8")
-                    ):
-                        listeners.extend(doc.get("listeners", []))
-                        clusters.extend(doc.get("clusters", []))
-                        for by in assignments.keys():
-                            for key, values in (
-                                doc.get("assignments", {}).get(by, {}).items()
-                            ):
-                                assignments[by].setdefault(key, {})
-                                for type in types:
-                                    assignments[by][key].setdefault(type, [])
-                                    assignments[by][key][type].extend(
-                                        values.get(type, [])
-                                    )
-
-        for by in assignments.keys():
-            for key in assignments[by].keys():
-                for type in types:
-                    assignments[by][key][type] = sorted(assignments[by][key][type])
-
-        def by_name(x):
-            return x["name"]
-
-        return safe_dump_all(
-            [
-                {
-                    "apiVersion": "v1",
-                    "kind": "ConfigMap",
-                    "metadata": {
-                        "name": "xds",
-                        "namespace": "sentry-system",
-                    },
-                    "data": {
-                        "listeners": safe_dump_all([sorted(listeners, key=by_name)]),
-                        "clusters": safe_dump_all([sorted(clusters, key=by_name)]),
-                        "assignments": safe_dump_all([assignments]),
-                    },
-                }
-            ]
-        )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import find_packages, setup
 
 macros = [
     "iap_service=sentry_kube.ext:IAPService",
-    "xds_configmap_from=sentry_kube.ext:XDSConfigMapFrom",
     "raise=libsentrykube.ext:RaiseExtension",
     "json_file=libsentrykube.ext:JsonFile",
     "values_of=libsentrykube.ext:ValuesOf",
@@ -21,7 +20,6 @@ macros = [
     "serviceaccount=libsentrykube.ext:ServiceAccount",
     "deep_merge=libsentrykube.ext:DeepMerge",
     "sysctl_initcontainer=libsentrykube.ext:SysctlInitContainer",
-    "xds_eds_cluster_config=libsentrykube.ext:XDSEDSClusterConfig",
     "service_registry_annotations=libsentrykube.ext:ServiceRegistryAnnotations",
     "service_registry_labels=libsentrykube.ext:ServiceRegistryLabels",
     "get_var=libsentrykube.ext:GetVar",


### PR DESCRIPTION
The xDS service was retired from ops in getsentry/ops#21060, so the extensions that generated its config are now dead code. This removes both XDS extensions, their macro registrations, and the imports they solely relied on.

Removed:
- `XDSEDSClusterConfig` (`libsentrykube.ext`) and its `xds_eds_cluster_config` macro, registered in both `setup.py` and `libsentrykube/setup.py`.
- `XDSConfigMapFrom` (`sentry_kube.ext`) and its `xds_configmap_from` macro, along with the imports only it used (`pathlib.Path`, `jinja2.FileSystemLoader`, `jinja2.pass_context`, `yaml.safe_load_all`, and the `Any`/`List`/`Optional` typing names).

No template, fixture, or test in this repo referenced these macros, and ops no longer uses them.