### PR TITLE
feat(ext): Add cronjob_image macro for SHA-pinned CronJob deploys

### DIFF
--- a/libsentrykube/ext.py
+++ b/libsentrykube/ext.py
@@ -10,7 +10,7 @@ import click
 import yaml
 from jinja2.ext import Extension
 from jinja2.utils import pass_context
-from kubernetes.client import AppsV1Api
+from kubernetes.client import AppsV1Api, BatchV1Api
 from kubernetes.client.rest import ApiException
 
 from libsentrykube.customer import get_machine_type_list
@@ -94,6 +94,42 @@ class StatefulSetImage(SimpleExtension):
                 return default
             raise
         for c in stateful_set.spec.template.spec.containers:
+            if c.name == container:
+                return c.image
+        return default
+
+
+class CronJobImage(SimpleExtension):
+    """
+    Query production Kubernetes cluster for CronJob image. If a CronJob
+    and container name combo exists, use this value found. If not, fall
+    back to default value. This should be paired with any CronJob that is
+    pushed out through by GoCD to make sure the image tag is correct. To be
+    used as the value to spec.jobTemplate.spec.template.spec.containers[*].image.
+    """
+
+    def run(self, cron_job_name: str, container: str, default: str):
+        if os.getenv("KUBERNETES_OFFLINE"):
+            return default
+
+        if "DEPLOYMENT_IMAGE" in os.environ:
+            return os.getenv("DEPLOYMENT_IMAGE")
+
+        namespace, name = kube_extract_namespace(cron_job_name)
+        client = kube_get_client()
+        try:
+            cron_job = BatchV1Api(client).read_namespaced_cron_job(
+                name,
+                namespace,
+                _request_timeout=os.getenv(
+                    KUBE_API_TIMEOUT_ENV_NAME, KUBE_API_TIMEOUT_DEFAULT
+                ),
+            )
+        except ApiException as e:
+            if e.status == 404:
+                return default
+            raise
+        for c in cron_job.spec.job_template.spec.template.spec.containers:
             if c.name == container:
                 return c.image
         return default

--- a/libsentrykube/setup.py
+++ b/libsentrykube/setup.py
@@ -6,6 +6,7 @@ default_macros = [
     "values_of=libsentrykube.ext:ValuesOf",
     "deployment_image=libsentrykube.ext:DeploymentImage",
     "statefulset_image=libsentrykube.ext:StatefulSetImage",
+    "cronjob_image=libsentrykube.ext:CronJobImage",
     "machine_info=libsentrykube.ext:MachineType",
     "md5file=libsentrykube.ext:Md5File",
     "md5template=libsentrykube.ext:Md5Template",

--- a/libsentrykube/tests/test_ext.py
+++ b/libsentrykube/tests/test_ext.py
@@ -435,3 +435,68 @@ def test_render_external_class_not_found():
 
     with pytest.raises(ValueError):
         render_external.run("libsentrykube.tests.test_ext.NotAnExternalMacro", context)
+
+
+def _make_cron_job(containers):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        spec=SimpleNamespace(
+            job_template=SimpleNamespace(
+                spec=SimpleNamespace(
+                    template=SimpleNamespace(
+                        spec=SimpleNamespace(containers=containers)
+                    )
+                )
+            )
+        )
+    )
+
+
+def _cronjob_image_ext():
+    from libsentrykube.ext import CronJobImage
+
+    CronJobImage.install("cronjob_image")
+    return CronJobImage()
+
+
+def test_cronjob_image_offline_returns_default(monkeypatch):
+    monkeypatch.setenv("KUBERNETES_OFFLINE", "1")
+    ext = _cronjob_image_ext()
+    assert ext.run("sentry-system/x-cronjob", "x", "img:latest") == "img:latest"
+
+
+def test_cronjob_image_env_override(monkeypatch):
+    monkeypatch.delenv("KUBERNETES_OFFLINE", raising=False)
+    monkeypatch.setenv("DEPLOYMENT_IMAGE", "img:override")
+    ext = _cronjob_image_ext()
+    assert ext.run("sentry-system/x-cronjob", "x", "img:latest") == "img:override"
+
+
+def test_cronjob_image_returns_live_image(monkeypatch):
+    from types import SimpleNamespace
+
+    monkeypatch.delenv("KUBERNETES_OFFLINE", raising=False)
+    monkeypatch.delenv("DEPLOYMENT_IMAGE", raising=False)
+
+    cron_job = _make_cron_job([SimpleNamespace(name="x", image="img:abc123")])
+    with patch("libsentrykube.ext.kube_get_client"), patch(
+        "libsentrykube.ext.BatchV1Api"
+    ) as api:
+        api.return_value.read_namespaced_cron_job.return_value = cron_job
+        ext = _cronjob_image_ext()
+        assert ext.run("sentry-system/x-cronjob", "x", "img:latest") == "img:abc123"
+
+
+def test_cronjob_image_missing_returns_default(monkeypatch):
+    from kubernetes.client.rest import ApiException
+
+    monkeypatch.delenv("KUBERNETES_OFFLINE", raising=False)
+    monkeypatch.delenv("DEPLOYMENT_IMAGE", raising=False)
+
+    with patch("libsentrykube.ext.kube_get_client"), patch(
+        "libsentrykube.ext.BatchV1Api"
+    ) as api:
+        api.return_value.read_namespaced_cron_job.side_effect = ApiException(status=404)
+        ext = _cronjob_image_ext()
+        assert ext.run("sentry-system/missing", "x", "img:latest") == "img:latest"


### PR DESCRIPTION
Adds a `cronjob_image` Jinja macro alongside the existing `deployment_image` and `statefulset_image` helpers.

Those helpers query the live cluster object (Deployment / StatefulSet) and return its current container image, falling back to a default only when the object doesn't exist. That preserves the image a GoCD `k8s-deploy --image=…:<sha>` set, so a subsequent GitOps `apply` of the manifest doesn't reset it. CronJobs had no equivalent — a CronJob manifest using `deployment_image` would never match a Deployment, so it would return the fallback tag on every render and clobber the deployed SHA on each apply.

`cronjob_image(name, container, default)` reads the live CronJob's `spec.jobTemplate.spec.template.spec.containers[*].image` via `BatchV1Api.read_namespaced_cron_job`, returning the default on a 404 — the same contract as the other two, adapted to the CronJob object shape.

This unblocks migrating `usage-accountant` (a CronJob) to GoCD deploy-by-SHA. Once released, `getsentry/ops` will switch its `usage-accountant` cronjob manifest to `cronjob_image(...)`.