### PR TITLE
fix(ext): Register cronjob_image entry point in the released package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ macros = [
     "values_of=libsentrykube.ext:ValuesOf",
     "deployment_image=libsentrykube.ext:DeploymentImage",
     "statefulset_image=libsentrykube.ext:StatefulSetImage",
+    "cronjob_image=libsentrykube.ext:CronJobImage",
     "machine_info=libsentrykube.ext:MachineType",
     "md5file=libsentrykube.ext:Md5File",
     "md5template=libsentrykube.ext:Md5Template",


### PR DESCRIPTION
`cronjob_image` (added in #237, released in 1.32.0) renders as `'cronjob_image' is undefined` — e.g. [this ops CI run](https://github.com/getsentry/ops/actions/runs/28105211664/job/83217520708).

Root cause: the macro was registered only in the inner `libsentrykube/setup.py`, but the released `sentry-infra-tools` distribution is built from the **root `setup.py`**, whose `libsentrykube.macros` list did not include it. So 1.32.0 shipped the `CronJobImage` class but never registered the `cronjob_image` entry point that `loader.load_macros()` discovers.

This adds the entry point to the root `setup.py` next to `deployment_image` / `statefulset_image`. A new release is required, after which `getsentry/ops#21440` must pin that version (1.32.0 is insufficient).