### PR TITLE
Add StatefulSet PVC reconciliation management CLI

### DIFF
--- a/libsentrykube/statefulset.py
+++ b/libsentrykube/statefulset.py
@@ -1,0 +1,467 @@
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+import click
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+from libsentrykube.utils import kube_get_client
+
+ANNOTATION_DESIRED = "sts-reconciler.sentry.io/desired-pvc-spec"
+ANNOTATION_STATUS = "sts-reconciler.sentry.io/status"
+ANNOTATION_SKIP = "sts-reconciler.sentry.io/skip"
+
+TERMINAL_STATES = {"Failed", "DryRun"}
+ACTIVE_STATES = {"Blocked", "Patching", "AwaitingConvergence", "Deleting"}
+
+
+@dataclass
+class PVCInfo:
+    name: str
+    ordinal: int
+    spec_storage: str
+    status_storage: Optional[str]
+    spec_vac: Optional[str]
+    status_vac: Optional[str]
+    storage_class: Optional[str]
+
+
+@dataclass
+class StatefulSetInfo:
+    name: str
+    namespace: str
+    replicas: int
+    ready_replicas: int
+    volume_claim_templates: list
+    desired_annotation: Optional[dict]
+    status_annotation: Optional[dict]
+    skip_annotation: bool
+
+
+def get_apps_api():
+    return client.AppsV1Api(kube_get_client())
+
+
+def get_core_api():
+    return client.CoreV1Api(kube_get_client())
+
+
+def read_statefulset(namespace: str, name: str) -> StatefulSetInfo:
+    apps_api = get_apps_api()
+    sts = apps_api.read_namespaced_stateful_set(name, namespace)
+
+    annotations = sts.metadata.annotations or {}
+
+    desired_raw = annotations.get(ANNOTATION_DESIRED)
+    desired = json.loads(desired_raw) if desired_raw else None
+
+    status_raw = annotations.get(ANNOTATION_STATUS)
+    status = json.loads(status_raw) if status_raw else None
+
+    skip = annotations.get(ANNOTATION_SKIP, "").lower() == "true"
+
+    vcts = []
+    if sts.spec.volume_claim_templates:
+        for vct in sts.spec.volume_claim_templates:
+            vcts.append(
+                {
+                    "name": vct.metadata.name,
+                    "storage": vct.spec.resources.requests.get("storage", ""),
+                    "storageClassName": vct.spec.storage_class_name or "",
+                    "volumeAttributesClassName": getattr(
+                        vct.spec, "volume_attributes_class_name", None
+                    )
+                    or "",
+                }
+            )
+
+    return StatefulSetInfo(
+        name=name,
+        namespace=namespace,
+        replicas=sts.spec.replicas or 0,
+        ready_replicas=sts.status.ready_replicas or 0,
+        volume_claim_templates=vcts,
+        desired_annotation=desired,
+        status_annotation=status,
+        skip_annotation=skip,
+    )
+
+
+def list_pvcs_for_statefulset(
+    namespace: str, sts_name: str, claim_names: list[str]
+) -> list[PVCInfo]:
+    core_api = get_core_api()
+    pvcs = []
+
+    for claim_name in claim_names:
+        label_selector = (
+            f"app.kubernetes.io/name={sts_name}"
+        )
+        try:
+            pvc_list = core_api.list_namespaced_persistent_volume_claim(
+                namespace=namespace,
+                label_selector=label_selector,
+            )
+        except ApiException:
+            pvc_list = type("obj", (object,), {"items": []})()
+
+        prefix = f"{claim_name}-{sts_name}-"
+        matched = []
+        for pvc in pvc_list.items:
+            if pvc.metadata.name.startswith(prefix):
+                try:
+                    ordinal = int(pvc.metadata.name[len(prefix) :])
+                except ValueError:
+                    continue
+                matched.append((ordinal, pvc))
+
+        if not matched:
+            for ordinal in range(100):
+                pvc_name = f"{claim_name}-{sts_name}-{ordinal}"
+                try:
+                    pvc = core_api.read_namespaced_persistent_volume_claim(
+                        pvc_name, namespace
+                    )
+                    matched.append((ordinal, pvc))
+                except ApiException as e:
+                    if e.status == 404:
+                        break
+                    raise
+
+        for ordinal, pvc in sorted(matched, key=lambda x: x[0]):
+            spec_storage = pvc.spec.resources.requests.get("storage", "?")
+            status_storage = None
+            if pvc.status and pvc.status.capacity:
+                status_storage = pvc.status.capacity.get("storage")
+
+            spec_vac = getattr(pvc.spec, "volume_attributes_class_name", None)
+            status_vac = getattr(
+                pvc.status, "current_volume_attributes_class_name", None
+            )
+            storage_class = pvc.spec.storage_class_name
+
+            pvcs.append(
+                PVCInfo(
+                    name=pvc.metadata.name,
+                    ordinal=ordinal,
+                    spec_storage=spec_storage,
+                    status_storage=status_storage,
+                    spec_vac=spec_vac,
+                    status_vac=status_vac,
+                    storage_class=storage_class,
+                )
+            )
+
+    return pvcs
+
+
+def build_desired_annotation(
+    claim_name: str,
+    storage: Optional[str] = None,
+    vac: Optional[str] = None,
+    batch_size: int = 0,
+) -> dict:
+    claim_spec = {}
+    if storage:
+        claim_spec["storage"] = storage
+    if vac:
+        claim_spec["volumeAttributesClassName"] = vac
+
+    annotation = {
+        "version": 1,
+        "claims": {claim_name: claim_spec},
+    }
+    if batch_size > 0:
+        annotation["batchSize"] = batch_size
+
+    return annotation
+
+
+def apply_desired_annotation(namespace: str, sts_name: str, annotation: dict) -> None:
+    apps_api = get_apps_api()
+    body = {
+        "metadata": {
+            "annotations": {
+                ANNOTATION_DESIRED: json.dumps(annotation),
+            }
+        }
+    }
+    apps_api.patch_namespaced_stateful_set(sts_name, namespace, body)
+
+
+def remove_annotations(namespace: str, sts_name: str) -> None:
+    apps_api = get_apps_api()
+    body = {
+        "metadata": {
+            "annotations": {
+                ANNOTATION_DESIRED: None,
+                ANNOTATION_STATUS: None,
+            }
+        }
+    }
+    apps_api.patch_namespaced_stateful_set(sts_name, namespace, body)
+
+
+def parse_storage_quantity(quantity: str) -> int:
+    """Parse a Kubernetes storage quantity string into bytes."""
+    quantity = quantity.strip()
+    suffixes = {
+        "Ki": 1024,
+        "Mi": 1024**2,
+        "Gi": 1024**3,
+        "Ti": 1024**4,
+        "K": 1000,
+        "M": 1000**2,
+        "G": 1000**3,
+        "T": 1000**4,
+    }
+    for suffix, multiplier in sorted(suffixes.items(), key=lambda x: -len(x[0])):
+        if quantity.endswith(suffix):
+            return int(quantity[: -len(suffix)]) * multiplier
+    return int(quantity)
+
+
+def validate_storage_expansion(current: str, target: str) -> None:
+    current_bytes = parse_storage_quantity(current)
+    target_bytes = parse_storage_quantity(target)
+    if target_bytes < current_bytes:
+        raise click.BadParameter(
+            f"Target storage {target} is smaller than current {current}. "
+            "Kubernetes does not support shrinking PVCs."
+        )
+    if target_bytes == current_bytes:
+        raise click.BadParameter(
+            f"Target storage {target} is the same as current {current}. "
+            "Nothing to do."
+        )
+
+
+def format_timestamp(ts_str: Optional[str]) -> str:
+    if not ts_str:
+        return "?"
+    try:
+        ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        delta = datetime.now(timezone.utc) - ts
+        total_seconds = int(delta.total_seconds())
+        if total_seconds < 60:
+            return f"{total_seconds}s ago"
+        elif total_seconds < 3600:
+            return f"{total_seconds // 60}m ago"
+        else:
+            return f"{total_seconds // 3600}h {(total_seconds % 3600) // 60}m ago"
+    except (ValueError, TypeError):
+        return ts_str
+
+
+def print_status(sts_info: StatefulSetInfo, pvcs: list[PVCInfo]) -> None:
+    click.echo(
+        f"StatefulSet: {sts_info.namespace}/{sts_info.name} "
+        f"({sts_info.replicas} replicas, {sts_info.ready_replicas} ready)"
+    )
+
+    if sts_info.skip_annotation:
+        click.secho("Skip:        true (controller will ignore this StatefulSet)", fg="yellow")
+
+    status = sts_info.status_annotation
+    if status:
+        state = status.get("state", "?")
+        since = format_timestamp(status.get("lastTransition"))
+        click.echo(f"State:       {state} (since {since})")
+
+        wave = status.get("waveOrdinals")
+        if wave is not None:
+            click.echo(f"Batch:       ordinals {wave}")
+
+        reason = status.get("reason")
+        if reason:
+            click.secho(f"Reason:      {reason}", fg="red")
+
+        click.echo()
+
+        pvc_statuses = status.get("pvcs", {})
+        header = f"  {'PVC':<30} {'Spec':<10} {'Status':<10} {'VAC':<20} {'State':<15}"
+        click.echo(header)
+        for pvc in pvcs:
+            pvc_state = pvc_statuses.get(pvc.name, "")
+            status_storage = pvc.status_storage or ""
+
+            spec_match = ""
+            if pvc.status_storage and pvc.spec_storage:
+                if pvc.status_storage == pvc.spec_storage:
+                    spec_match = click.style(pvc.status_storage, fg="green")
+                else:
+                    spec_match = click.style(pvc.status_storage + " ...", fg="yellow")
+            else:
+                spec_match = status_storage
+
+            vac_display = pvc.spec_vac or "-"
+            click.echo(
+                f"  {pvc.name:<30} {pvc.spec_storage:<10} "
+                f"{spec_match:<10} {vac_display:<20} {pvc_state:<15}"
+            )
+    elif sts_info.desired_annotation:
+        click.secho(
+            "State:       pending (annotation set, controller has not started)",
+            fg="yellow",
+        )
+        click.echo()
+        _print_pvc_table_idle(pvcs)
+    else:
+        click.echo("State:       idle (no reconcile in progress)")
+        click.echo()
+        _print_pvc_table_idle(pvcs)
+
+
+def _print_pvc_table_idle(pvcs: list[PVCInfo]) -> None:
+    header = f"  {'PVC':<30} {'Storage':<10} {'VAC':<20}"
+    click.echo(header)
+    for pvc in pvcs:
+        vac = pvc.spec_vac or "-"
+        click.echo(f"  {pvc.name:<30} {pvc.spec_storage:<10} {vac:<20}")
+
+
+def print_resize_preview(
+    sts_info: StatefulSetInfo,
+    pvcs: list[PVCInfo],
+    claim_name: str,
+    target_storage: Optional[str],
+    target_vac: Optional[str],
+    batch_size: int,
+) -> None:
+    click.echo(
+        f"StatefulSet: {sts_info.namespace}/{sts_info.name} "
+        f"({sts_info.replicas} replicas, {sts_info.ready_replicas} ready)"
+    )
+
+    storage_class = ""
+    for pvc in pvcs:
+        if pvc.storage_class:
+            storage_class = pvc.storage_class
+            break
+
+    sc_display = f" (storageClass: {storage_class})" if storage_class else ""
+    click.echo(f"\n  Claim: {claim_name}{sc_display}\n")
+
+    header = f"  {'PVC':<30} {'Current':<12} {'Target':<12} {'Change'}"
+    click.echo(header)
+
+    for pvc in pvcs:
+        changes = []
+        target_col = ""
+
+        if target_storage:
+            target_col = target_storage
+            if pvc.spec_storage != target_storage:
+                changes.append("expand storage")
+            else:
+                changes.append("(no change)")
+        else:
+            target_col = pvc.spec_storage
+
+        if target_vac:
+            if pvc.spec_vac != target_vac:
+                changes.append(f"set VAC -> {target_vac}")
+
+        change_str = ", ".join(changes) if changes else "(no change)"
+        click.echo(f"  {pvc.name:<30} {pvc.spec_storage:<12} {target_col:<12} {change_str}")
+
+    if batch_size > 0:
+        ordinals = [pvc.ordinal for pvc in pvcs]
+        batches = []
+        for i in range(0, len(ordinals), batch_size):
+            batches.append(ordinals[i : i + batch_size])
+        batch_desc = ", then ".join(str(b) for b in batches)
+        click.echo(f"\n  Batch size: {batch_size} (ordinals {batch_desc})")
+
+    click.echo(
+        "\n  After PVCs converge, the StatefulSet will be orphan-deleted"
+        "\n  (pods keep running) and recreated with updated volumeClaimTemplates."
+    )
+
+
+def monitor_reconciliation(
+    namespace: str,
+    sts_name: str,
+    claim_names: list[str],
+    poll_interval: float = 3.0,
+) -> bool:
+    last_state = None
+    last_pvc_states: dict[str, str] = {}
+
+    click.echo()
+    while True:
+        try:
+            sts_info = read_statefulset(namespace, sts_name)
+        except ApiException as e:
+            if e.status == 404:
+                _log("StatefulSet not found (may have been orphan-deleted)")
+                _log("Waiting for recreation...")
+                if _wait_for_sts_recreation(namespace, sts_name, poll_interval):
+                    _log("StatefulSet recreated")
+                    sts_info = read_statefulset(namespace, sts_name)
+                    if sts_info.ready_replicas == sts_info.replicas:
+                        _log(
+                            f"Rollout complete "
+                            f"({sts_info.ready_replicas}/{sts_info.replicas} replicas ready)"
+                        )
+                        click.secho("Done", fg="green", bold=True)
+                        return True
+                else:
+                    click.secho(
+                        "Timed out waiting for StatefulSet recreation.", fg="red"
+                    )
+                    return False
+            raise
+
+        status = sts_info.status_annotation
+
+        if not status and not sts_info.desired_annotation:
+            _log("Reconciliation complete (annotations cleared)")
+            click.secho("Done", fg="green", bold=True)
+            return True
+
+        if not status:
+            time.sleep(poll_interval)
+            continue
+
+        state = status.get("state", "?")
+        if state != last_state:
+            _log(f"State: {state}")
+            last_state = state
+
+        if state in TERMINAL_STATES:
+            reason = status.get("reason", "unknown")
+            click.secho(f"  Reason: {reason}", fg="red")
+            return state != "Failed"
+
+        pvc_statuses = status.get("pvcs", {})
+        for pvc_name, pvc_state in pvc_statuses.items():
+            if pvc_state != last_pvc_states.get(pvc_name):
+                _log(f"  {pvc_name}: {pvc_state}")
+                last_pvc_states[pvc_name] = pvc_state
+
+        time.sleep(poll_interval)
+
+
+def _wait_for_sts_recreation(
+    namespace: str, sts_name: str, poll_interval: float, timeout: float = 600
+) -> bool:
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        try:
+            read_statefulset(namespace, sts_name)
+            return True
+        except ApiException as e:
+            if e.status == 404:
+                time.sleep(poll_interval)
+                continue
+            raise
+    return False
+
+
+def _log(message: str) -> None:
+    ts = datetime.now().strftime("%H:%M:%S")
+    click.echo(f"[{ts}] {message}")

--- a/libsentrykube/statefulset.py
+++ b/libsentrykube/statefulset.py
@@ -17,6 +17,15 @@ ANNOTATION_SKIP = "sts-reconciler.sentry.io/skip"
 TERMINAL_STATES = {"Failed", "DryRun"}
 ACTIVE_STATES = {"Blocked", "Patching", "AwaitingConvergence", "Deleting"}
 
+RESIZE_EVENT_REASONS = {
+    "VolumeResizeFailed",
+    "ExternalExpanding",
+    "Resizing",
+    "FileSystemResizeRequired",
+    "FileSystemResizeSuccessful",
+    "VolumeResizeSuccessful",
+}
+
 
 @dataclass
 class PVCInfo:
@@ -47,6 +56,56 @@ def get_apps_api():
 
 def get_core_api():
     return client.CoreV1Api(kube_get_client())
+
+
+def get_pvc_warning_events(
+    namespace: str, pvc_names: list[str], since_minutes: int = 30
+) -> dict[str, list[str]]:
+    """Fetch recent warning events for the given PVCs, filtered to resize-related reasons."""
+    core_api = get_core_api()
+    result: dict[str, list[str]] = {}
+    for pvc_name in pvc_names:
+        try:
+            events = core_api.list_namespaced_event(
+                namespace=namespace,
+                field_selector=f"involvedObject.name={pvc_name},involvedObject.kind=PersistentVolumeClaim,type=Warning",
+            )
+        except ApiException:
+            continue
+
+        messages = []
+        for event in events.items:
+            reason = event.reason or ""
+            if reason not in RESIZE_EVENT_REASONS:
+                continue
+            age = ""
+            event_time = event.last_timestamp or event.event_time
+            if event_time:
+                if hasattr(event_time, "replace"):
+                    try:
+                        delta = datetime.now(timezone.utc) - event_time.replace(
+                            tzinfo=timezone.utc
+                        )
+                        total_sec = int(delta.total_seconds())
+                        if total_sec < 0 or total_sec > since_minutes * 60:
+                            continue
+                        if total_sec < 60:
+                            age = f"{total_sec}s ago"
+                        else:
+                            age = f"{total_sec // 60}m ago"
+                    except (ValueError, TypeError):
+                        pass
+
+            count = event.count or 1
+            msg = event.message or ""
+            count_str = f" (x{count})" if count > 1 else ""
+            age_str = f" [{age}]" if age else ""
+            messages.append(f"{reason}{count_str}{age_str}: {msg}")
+
+        if messages:
+            result[pvc_name] = messages
+
+    return result
 
 
 def read_statefulset(namespace: str, name: str) -> StatefulSetInfo:
@@ -302,6 +361,16 @@ def print_status(sts_info: StatefulSetInfo, pvcs: list[PVCInfo]) -> None:
                 f"  {pvc.name:<30} {pvc.spec_storage:<10} "
                 f"{spec_match:<10} {vac_display:<20} {pvc_state:<15}"
             )
+
+        pvc_events = get_pvc_warning_events(
+            sts_info.namespace, [p.name for p in pvcs]
+        )
+        if pvc_events:
+            click.echo()
+            click.secho("  Events:", bold=True)
+            for pvc_name, messages in pvc_events.items():
+                for msg in messages:
+                    click.secho(f"    {pvc_name}: {msg}", fg="yellow")
     elif sts_info.desired_annotation:
         click.secho(
             "State:       pending (annotation set, controller has not started)",
@@ -390,6 +459,8 @@ def monitor_reconciliation(
 ) -> bool:
     last_state = None
     last_pvc_states: dict[str, str] = {}
+    seen_event_keys: set[str] = set()
+    polls_since_event_check = 0
 
     click.echo()
     while True:
@@ -442,6 +513,19 @@ def monitor_reconciliation(
             if pvc_state != last_pvc_states.get(pvc_name):
                 _log(f"  {pvc_name}: {pvc_state}")
                 last_pvc_states[pvc_name] = pvc_state
+
+        polls_since_event_check += 1
+        if polls_since_event_check >= 3:
+            polls_since_event_check = 0
+            pvc_names = list(pvc_statuses.keys())
+            if pvc_names:
+                pvc_events = get_pvc_warning_events(namespace, pvc_names, since_minutes=5)
+                for pvc_name, messages in pvc_events.items():
+                    for msg in messages:
+                        event_key = f"{pvc_name}:{msg}"
+                        if event_key not in seen_event_keys:
+                            seen_event_keys.add(event_key)
+                            _log(click.style(f"  {pvc_name}: {msg}", fg="yellow"))
 
         time.sleep(poll_interval)
 

--- a/libsentrykube/tests/test_statefulset.py
+++ b/libsentrykube/tests/test_statefulset.py
@@ -1,0 +1,149 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from libsentrykube.statefulset import (
+    ANNOTATION_DESIRED,
+    ANNOTATION_STATUS,
+    ANNOTATION_SKIP,
+    PVCInfo,
+    StatefulSetInfo,
+    build_desired_annotation,
+    format_timestamp,
+    parse_storage_quantity,
+    validate_storage_expansion,
+)
+
+
+class TestParseStorageQuantity:
+    def test_gi(self):
+        assert parse_storage_quantity("10Gi") == 10 * 1024**3
+
+    def test_mi(self):
+        assert parse_storage_quantity("500Mi") == 500 * 1024**2
+
+    def test_ti(self):
+        assert parse_storage_quantity("1Ti") == 1024**4
+
+    def test_ki(self):
+        assert parse_storage_quantity("100Ki") == 100 * 1024
+
+    def test_decimal_g(self):
+        assert parse_storage_quantity("10G") == 10 * 1000**3
+
+    def test_plain_bytes(self):
+        assert parse_storage_quantity("1073741824") == 1073741824
+
+    def test_whitespace(self):
+        assert parse_storage_quantity("  10Gi  ") == 10 * 1024**3
+
+
+class TestValidateStorageExpansion:
+    def test_valid_expansion(self):
+        validate_storage_expansion("10Gi", "20Gi")
+
+    def test_shrink_raises(self):
+        with pytest.raises(click.BadParameter, match="smaller"):
+            validate_storage_expansion("20Gi", "10Gi")
+
+    def test_same_size_raises(self):
+        with pytest.raises(click.BadParameter, match="same"):
+            validate_storage_expansion("10Gi", "10Gi")
+
+
+class TestBuildDesiredAnnotation:
+    def test_storage_only(self):
+        result = build_desired_annotation("data", storage="20Gi")
+        assert result == {
+            "version": 1,
+            "claims": {"data": {"storage": "20Gi"}},
+        }
+
+    def test_vac_only(self):
+        result = build_desired_annotation("data", vac="vac-fast")
+        assert result == {
+            "version": 1,
+            "claims": {"data": {"volumeAttributesClassName": "vac-fast"}},
+        }
+
+    def test_both(self):
+        result = build_desired_annotation("data", storage="20Gi", vac="vac-fast")
+        assert result == {
+            "version": 1,
+            "claims": {
+                "data": {
+                    "storage": "20Gi",
+                    "volumeAttributesClassName": "vac-fast",
+                }
+            },
+        }
+
+    def test_batch_size(self):
+        result = build_desired_annotation("data", storage="20Gi", batch_size=2)
+        assert result == {
+            "version": 1,
+            "claims": {"data": {"storage": "20Gi"}},
+            "batchSize": 2,
+        }
+
+    def test_batch_size_zero_omitted(self):
+        result = build_desired_annotation("data", storage="20Gi", batch_size=0)
+        assert "batchSize" not in result
+
+
+class TestFormatTimestamp:
+    def test_none(self):
+        assert format_timestamp(None) == "?"
+
+    def test_invalid(self):
+        assert format_timestamp("not-a-date") == "not-a-date"
+
+    def test_recent(self):
+        from datetime import datetime, timezone, timedelta
+
+        ts = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
+        result = format_timestamp(ts)
+        assert result.endswith("s ago")
+
+    def test_minutes(self):
+        from datetime import datetime, timezone, timedelta
+
+        ts = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        result = format_timestamp(ts)
+        assert result.endswith("m ago")
+
+
+class TestStatefulSetInfo:
+    def test_idle_state(self):
+        info = StatefulSetInfo(
+            name="broker",
+            namespace="taskbroker",
+            replicas=3,
+            ready_replicas=3,
+            volume_claim_templates=[
+                {"name": "data", "storage": "10Gi", "storageClassName": "standard", "volumeAttributesClassName": ""},
+            ],
+            desired_annotation=None,
+            status_annotation=None,
+            skip_annotation=False,
+        )
+        assert info.replicas == 3
+        assert info.desired_annotation is None
+
+    def test_active_state(self):
+        info = StatefulSetInfo(
+            name="broker",
+            namespace="taskbroker",
+            replicas=3,
+            ready_replicas=3,
+            volume_claim_templates=[
+                {"name": "data", "storage": "10Gi", "storageClassName": "standard", "volumeAttributesClassName": ""},
+            ],
+            desired_annotation={"version": 1, "claims": {"data": {"storage": "20Gi"}}},
+            status_annotation={"version": 1, "state": "Patching", "pvcs": {}},
+            skip_annotation=False,
+        )
+        assert info.desired_annotation is not None
+        assert info.status_annotation["state"] == "Patching"

--- a/sentry_kube/cli/statefulset.py
+++ b/sentry_kube/cli/statefulset.py
@@ -1,0 +1,216 @@
+import sys
+
+import click
+
+from libsentrykube.statefulset import (
+    apply_desired_annotation,
+    build_desired_annotation,
+    list_pvcs_for_statefulset,
+    monitor_reconciliation,
+    print_resize_preview,
+    print_status,
+    read_statefulset,
+    remove_annotations,
+    validate_storage_expansion,
+)
+
+__all__ = ("statefulset", "sts")
+
+
+class _AliasedGroup(click.Group):
+    """A click.Group subclass that supports lazy-copying commands from a source group."""
+
+    def __init__(self, *args, source_group=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._source_group = source_group
+
+    def list_commands(self, ctx):
+        if self._source_group:
+            return self._source_group.list_commands(ctx)
+        return super().list_commands(ctx)
+
+    def get_command(self, ctx, cmd_name):
+        if self._source_group:
+            return self._source_group.get_command(ctx, cmd_name)
+        return super().get_command(ctx, cmd_name)
+
+
+@click.group(name="statefulset")
+def statefulset():
+    """Manage StatefulSet PVC reconciliation via kube-sts-reconciler."""
+    pass
+
+
+sts = _AliasedGroup(name="sts", help="Alias for 'statefulset'.", source_group=statefulset, hidden=True)
+
+
+@statefulset.command()
+@click.argument("namespace")
+@click.argument("sts_name")
+@click.pass_context
+def status(ctx, namespace, sts_name):
+    """Show current reconcile state of a StatefulSet."""
+    sts_info = read_statefulset(namespace, sts_name)
+
+    claim_names = [vct["name"] for vct in sts_info.volume_claim_templates]
+    if not claim_names:
+        click.echo(
+            f"StatefulSet {namespace}/{sts_name} has no volumeClaimTemplates."
+        )
+        return
+
+    pvcs = list_pvcs_for_statefulset(namespace, sts_name, claim_names)
+    print_status(sts_info, pvcs)
+
+
+@statefulset.command()
+@click.argument("namespace")
+@click.argument("sts_name")
+@click.option("--claim", "claim_name", help="volumeClaimTemplate name (required if multiple exist)")
+@click.option("--storage", help="Target storage size (e.g. 20Gi)")
+@click.option("--vac", help="Target VolumeAttributesClass name")
+@click.option("--batch-size", type=int, default=0, help="Patch N ordinals at a time (0 = all at once)")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@click.option("--no-monitor", is_flag=True, help="Apply annotation and exit without monitoring")
+@click.pass_context
+def resize(ctx, namespace, sts_name, claim_name, storage, vac, batch_size, yes, no_monitor):
+    """Resize PVCs for a StatefulSet via kube-sts-reconciler.
+
+    Requires --storage and/or --vac to specify the target PVC spec.
+    """
+    if not storage and not vac:
+        raise click.UsageError(
+            "At least one of --storage or --vac must be specified."
+        )
+
+    sts_info = read_statefulset(namespace, sts_name)
+
+    if sts_info.desired_annotation:
+        click.secho(
+            f"A reconcile is already in progress for {namespace}/{sts_name}.",
+            fg="red",
+        )
+        click.echo(
+            "Use 'sentry-kube statefulset cancel' to stop it first, "
+            "or 'sentry-kube statefulset status' to check progress."
+        )
+        sys.exit(1)
+
+    if sts_info.skip_annotation:
+        click.secho(
+            f"StatefulSet {namespace}/{sts_name} has skip=true annotation. "
+            "The controller will not act on it.",
+            fg="yellow",
+        )
+        if not yes and not click.confirm("Continue anyway?"):
+            raise click.Abort()
+
+    vcts = sts_info.volume_claim_templates
+    if not vcts:
+        click.echo(f"StatefulSet {namespace}/{sts_name} has no volumeClaimTemplates.")
+        sys.exit(1)
+
+    if claim_name:
+        matching = [v for v in vcts if v["name"] == claim_name]
+        if not matching:
+            available = ", ".join(v["name"] for v in vcts)
+            raise click.BadParameter(
+                f"Claim '{claim_name}' not found. Available: {available}",
+                param_hint="--claim",
+            )
+    elif len(vcts) == 1:
+        claim_name = vcts[0]["name"]
+    else:
+        available = ", ".join(v["name"] for v in vcts)
+        raise click.UsageError(
+            f"Multiple volumeClaimTemplates found ({available}). "
+            "Use --claim to specify which one."
+        )
+
+    pvcs = list_pvcs_for_statefulset(namespace, sts_name, [claim_name])
+    if not pvcs:
+        click.echo(f"No PVCs found for claim '{claim_name}' on {namespace}/{sts_name}.")
+        sys.exit(1)
+
+    if storage:
+        for pvc in pvcs:
+            validate_storage_expansion(pvc.spec_storage, storage)
+
+    print_resize_preview(sts_info, pvcs, claim_name, storage, vac, batch_size)
+
+    click.echo()
+    click.secho(
+        "WARNING: The code has not been updated. Make sure the next deploy uses "
+        "matching volumeClaimTemplate values.",
+        fg="yellow",
+    )
+
+    if not yes and not click.confirm("\nProceed?"):
+        raise click.Abort()
+
+    annotation = build_desired_annotation(claim_name, storage, vac, batch_size)
+    click.echo(f"\nApplying annotation to {namespace}/{sts_name}...")
+    apply_desired_annotation(namespace, sts_name, annotation)
+    click.echo("Annotation applied.")
+
+    if no_monitor:
+        click.echo(
+            "Use 'sentry-kube statefulset status' to check progress, "
+            "or re-run without --no-monitor to stream live updates."
+        )
+        return
+
+    click.echo("Monitoring reconciliation (Ctrl-C to detach, operation continues)...")
+    try:
+        success = monitor_reconciliation(namespace, sts_name, [claim_name])
+    except KeyboardInterrupt:
+        click.echo("\nDetached. The controller continues working in the background.")
+        click.echo("Use 'sentry-kube statefulset status' to check progress.")
+        return
+
+    if not success:
+        sys.exit(1)
+
+
+@statefulset.command()
+@click.argument("namespace")
+@click.argument("sts_name")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+@click.pass_context
+def cancel(ctx, namespace, sts_name, yes):
+    """Cancel an in-progress reconcile by removing annotations.
+
+    PVCs already patched stay patched (storage expansion is irreversible).
+    """
+    sts_info = read_statefulset(namespace, sts_name)
+
+    if not sts_info.desired_annotation and not sts_info.status_annotation:
+        click.echo(f"No reconcile in progress for {namespace}/{sts_name}.")
+        return
+
+    if sts_info.status_annotation:
+        state = sts_info.status_annotation.get("state", "?")
+        click.echo(f"Current state: {state}")
+
+        if state == "Deleting":
+            click.secho(
+                "\nWARNING: StatefulSet may have already been orphan-deleted. "
+                "Canceling will leave it deleted.\n"
+                "You must manually recreate it or trigger a deploy.",
+                fg="red",
+            )
+
+    claim_names = [vct["name"] for vct in sts_info.volume_claim_templates]
+    pvcs = list_pvcs_for_statefulset(namespace, sts_name, claim_names)
+
+    patched = [p for p in pvcs if p.spec_storage != p.status_storage]
+    if patched:
+        click.echo(f"\n{len(patched)} PVC(s) have pending storage changes (irreversible).")
+
+    if not yes and not click.confirm(
+        f"\nRemove reconciler annotations from {namespace}/{sts_name}?"
+    ):
+        raise click.Abort()
+
+    remove_annotations(namespace, sts_name)
+    click.echo("Annotations removed. Controller will stop acting on this StatefulSet.")

--- a/sentry_kube/cli/statefulset.py
+++ b/sentry_kube/cli/statefulset.py
@@ -86,15 +86,44 @@ def resize(ctx, namespace, sts_name, claim_name, storage, vac, batch_size, yes, 
     sts_info = read_statefulset(namespace, sts_name)
 
     if sts_info.desired_annotation:
-        click.secho(
-            f"A reconcile is already in progress for {namespace}/{sts_name}.",
-            fg="red",
-        )
-        click.echo(
-            "Use 'sentry-kube statefulset cancel' to stop it first, "
-            "or 'sentry-kube statefulset status' to check progress."
-        )
-        sys.exit(1)
+        status = sts_info.status_annotation or {}
+        state = status.get("state", "")
+
+        if state == "Failed":
+            reason = status.get("reason", "unknown")
+            click.secho(
+                f"Previous reconcile failed for {namespace}/{sts_name}:",
+                fg="red",
+            )
+            click.echo(f"  Reason: {reason}\n")
+
+            if not yes and not click.confirm("Clear failed state and retry?"):
+                raise click.Abort()
+
+            remove_annotations(namespace, sts_name)
+            click.echo("Cleared failed annotations.")
+        elif state in ("Blocked", "Patching", "AwaitingConvergence", "Deleting"):
+            click.secho(
+                f"A reconcile is already active for {namespace}/{sts_name} "
+                f"(state: {state}).",
+                fg="red",
+            )
+            click.echo(
+                "Use 'sentry-kube statefulset cancel' to stop it first, "
+                "or 'sentry-kube statefulset status' to check progress."
+            )
+            sys.exit(1)
+        else:
+            click.secho(
+                f"A reconcile annotation exists for {namespace}/{sts_name} "
+                f"(state: {state or 'pending'}).",
+                fg="red",
+            )
+            click.echo(
+                "Use 'sentry-kube statefulset cancel' to stop it first, "
+                "or 'sentry-kube statefulset status' to check progress."
+            )
+            sys.exit(1)
 
     if sts_info.skip_annotation:
         click.secho(
@@ -134,7 +163,8 @@ def resize(ctx, namespace, sts_name, claim_name, storage, vac, batch_size, yes, 
 
     if storage:
         for pvc in pvcs:
-            validate_storage_expansion(pvc.spec_storage, storage)
+            if pvc.spec_storage != storage:
+                validate_storage_expansion(pvc.spec_storage, storage)
 
     print_resize_preview(sts_info, pvcs, claim_name, storage, vac, batch_size)
 


### PR DESCRIPTION
## Summary

Adds a `sentry-kube statefulset` (alias: `sts`) command group for driving the `kube-sts-reconciler` controller. Instead of hand-crafting annotation JSON and polling with kubectl, operators get a preview → confirm → monitor workflow.

**Commands:**
- `statefulset status` — show current reconcile state, PVC details, and CSI driver events
- `statefulset resize` — apply `desired-pvc-spec` annotation with `--storage`/`--vac` flags, then monitor progress
- `statefulset cancel` — remove reconciler annotations to stop in-progress work

This PR implements **explicit flag mode** only (`--storage`, `--vac`). Template-diff mode (auto-detecting changes from local code) will be a follow-up.

## Demo

### Idle status

```
❯ sk s4s2 statefulset status sts-reconciler-test test-sts
StatefulSet: sts-reconciler-test/test-sts (1 replicas, 1 ready)
State:       idle (no reconcile in progress)

  PVC                            Storage    VAC
  data-test-sts-0                12Gi       -
```

### Resize preview and monitoring

```
❯ sk s4s2 sts resize sts-reconciler-test test-sts --storage 13Gi
StatefulSet: sts-reconciler-test/test-sts (1 replicas, 1 ready)

  Claim: data (storageClass: hyperdisk-balanced)

  PVC                            Current      Target       Change
  data-test-sts-0                12Gi         13Gi         expand storage

  After PVCs converge, the StatefulSet will be orphan-deleted
  (pods keep running) and recreated with updated volumeClaimTemplates.

WARNING: The code has not been updated. Make sure the next deploy uses matching volumeClaimTemplate values.

Proceed? [y/N]: y

Applying annotation to sts-reconciler-test/test-sts...
Annotation applied.
Monitoring reconciliation (Ctrl-C to detach, operation continues)...

[11:49:43] State: Patching
[11:49:43]   data-test-sts-0: NeedsPatch
[11:49:46] State: AwaitingConvergence
[11:49:46]   data-test-sts-0: AwaitingConvergence
```

### Failed resize with PVC event surfacing

In this test, GCP rate-limited the disk resize. The CLI surfaces the CSI driver warning events alongside the controller's failure reason:

```
❯ sk s4s2 statefulset status sts-reconciler-test test-sts
StatefulSet: sts-reconciler-test/test-sts (1 replicas, 1 ready)
State:       Failed (since 1m ago)
Reason:      ConvergenceTimeout: PVCs did not converge within 10m0s: data-test-sts-0:
             waiting for volume expansion to 13Gi (current capacity 12Gi)

  PVC                            Spec       Status     VAC                  State
  data-test-sts-0                13Gi       12Gi ...   -                    AwaitingConvergence

  Events:
    data-test-sts-0: VolumeResizeFailed (x6) [1m ago]: resize volume
      "pvc-f7bb65bb-ccf8-4a82-a53e-0908a78688a9" by resizer "pd.csi.storage.gke.io"
      failed: rpc error: code = InvalidArgument desc = ControllerExpandVolume failed
      to resize disk: ... googleapi: Error 400: Disk cannot be resized due to being
      rate limited., badRequest
```

## Key design decisions

- **Annotation-driven**: writes `sts-reconciler.sentry.io/desired-pvc-spec`, then monitors the controller's `status` annotation and PVC events
- **Python K8s client**: uses the existing `kube_get_client()` singleton for structured API access
- **PVC discovery**: tries label selector first (`app.kubernetes.io/name=<sts>`), falls back to name convention (`<claim>-<sts>-<ordinal>`)
- **Ctrl-C detaches**: exiting the monitor doesn't cancel the operation — the controller keeps working
- **Validation**: prevents shrinking PVCs, requires explicit `--claim` when multiple volumeClaimTemplates exist

## Files

- `libsentrykube/statefulset.py` — core library (K8s reads, annotation management, monitoring, display)
- `sentry_kube/cli/statefulset.py` — CLI commands + `sts` alias group
- `libsentrykube/tests/test_statefulset.py` — 21 unit tests

https://claude.ai/code/session_01AdyM1zGgTsXgz7MQyhmVaF