### PR TITLE
fix: keep multiline important diffs readable

### DIFF
--- a/libsentrykube/kubectl/important_diffs.py
+++ b/libsentrykube/kubectl/important_diffs.py
@@ -21,6 +21,30 @@ import yaml
 DEFAULT_DIFF_COMMAND = "diff -u -N"
 
 
+def _can_use_literal_block(value: str) -> bool:
+    return "\n" in value and all(char == "\n" or " " <= char <= "~" for char in value)
+
+
+class _ReadableMultilineDumper(yaml.SafeDumper):
+    def analyze_scalar(self, scalar: str) -> Any:
+        analysis = super().analyze_scalar(scalar)
+
+        # PyYAML rejects literal blocks when a line has trailing spaces, even
+        # though YAML supports them. Restrict the override to printable text.
+        if _can_use_literal_block(scalar):
+            analysis.allow_block = True
+
+        return analysis
+
+
+def _represent_string(dumper: yaml.SafeDumper, value: str) -> yaml.nodes.ScalarNode:
+    style = "|" if _can_use_literal_block(value) else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
+
+
+_ReadableMultilineDumper.add_representer(str, _represent_string)
+
+
 @dataclasses.dataclass(frozen=True, eq=True)
 class ApplyResult:
     original_values: Any
@@ -204,7 +228,7 @@ def process_file(
         ) from e
 
     apply_results = [rule.apply(data) for rule in RULES if rule.should_apply(data)]
-    yaml.safe_dump(data, output_stream)
+    yaml.dump(data, output_stream, Dumper=_ReadableMultilineDumper)
 
     return apply_results
 

--- a/libsentrykube/tests/kubectl/test_important_diffs.py
+++ b/libsentrykube/tests/kubectl/test_important_diffs.py
@@ -67,6 +67,17 @@ spec:
       terminationGracePeriodSeconds: 30
 """
 
+TEST_CONFIGMAP_DATA = """\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: multiline-config
+data:
+  config: |
+    first line with trailing spaces{trailing_spaces}
+    second line
+""".format(trailing_spaces="  ")
+
 
 def test_process_data() -> None:
     input_stream = io.StringIO(TEST_DEPLOYMENT_DATA)
@@ -104,3 +115,18 @@ def test_process_data() -> None:
         "image" not in container
         for container in data["spec"]["template"]["spec"]["containers"]
     ), "image should be ignored"
+
+
+def test_process_data_keeps_multiline_strings_readable() -> None:
+    output_stream = io.StringIO()
+
+    important_diffs.process_file(
+        "/tmp/configmap.yaml",
+        io.StringIO(TEST_CONFIGMAP_DATA),
+        output_stream,
+    )
+
+    output = output_stream.getvalue()
+    assert yaml.safe_load(output) == yaml.safe_load(TEST_CONFIGMAP_DATA)
+    assert "  config: |\n" in output
+    assert "    first line with trailing spaces  \n" in output


### PR DESCRIPTION
## Summary

- keep printable multiline YAML values as literal blocks while filtering unimportant Kubernetes fields
- allow literal blocks for lines with trailing spaces so `sentry-kube diff -i` does not produce escaped `\n` output
- cover the ConfigMap round-trip and readable rendering regression

Fixes #93

## Testing

- `python -m pytest libsentrykube/tests/kubectl/test_important_diffs.py -q`
- `ruff check libsentrykube/kubectl/important_diffs.py libsentrykube/tests/kubectl/test_important_diffs.py`
- `ruff format --check libsentrykube/kubectl/important_diffs.py libsentrykube/tests/kubectl/test_important_diffs.py`
- `mypy libsentrykube/kubectl/important_diffs.py`
- `python -m compileall -q libsentrykube/kubectl/important_diffs.py libsentrykube/tests/kubectl/test_important_diffs.py`
- before/after unified diff assertion for trailing-space ConfigMap content
