### PR TITLE
Add an agent inside sentry-kube to help people make k8s manifest changes

### DIFF
--- a/libsentrykube/agent.py
+++ b/libsentrykube/agent.py
@@ -1,14 +1,18 @@
 import os
 from dataclasses import dataclass
-from typing import Any, Optional, Sequence
+from typing import Any, Optional
 
 from langchain.agents import create_agent
 from langchain_core.tools import BaseTool
 from langchain_openai import ChatOpenAI
 
+from libsentrykube.prompts import SYSTEM_PROMPT, USER_PROMPT
 
 DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
 DEFAULT_MODEL = "anthropic/claude-sonnet-4.5"
+
+# The tools the agent is given. Add them here.
+TOOLS: list[BaseTool] = []
 
 
 class AgentConfigurationError(Exception):
@@ -44,16 +48,16 @@ def load_agent_config() -> AgentConfig:
 
 def run_agent(
     query: str,
-    system_prompt: Optional[str] = None,
-    tools: Optional[Sequence[BaseTool]] = None,
+    region: str,
+    cluster: Optional[str] = None,
     config: Optional[AgentConfig] = None,
 ) -> str:
     """
     Runs `query` through a langchain agent and returns the agent's response.
 
-    `system_prompt` and `tools` are optional so callers can shape the agent
-    without this module knowing about them. `config` defaults to being read from
-    the environment.
+    The prompts live in `libsentrykube.prompts`. `region` and `cluster` describe
+    what the operator is working on and are rendered into the user prompt.
+    `config` defaults to being read from the environment.
     """
     if config is None:
         config = load_agent_config()
@@ -66,11 +70,13 @@ def run_agent(
 
     agent = create_agent(
         model=model,
-        tools=list(tools) if tools else [],
-        system_prompt=system_prompt,
+        tools=TOOLS,
+        system_prompt=SYSTEM_PROMPT,
     )
 
-    result = agent.invoke({"messages": [{"role": "user", "content": query}]})
+    content = USER_PROMPT.format(query=query, region=region, cluster=cluster or "")
+
+    result = agent.invoke({"messages": [{"role": "user", "content": content}]})
 
     return _message_text(result["messages"][-1])
 

--- a/libsentrykube/agent.py
+++ b/libsentrykube/agent.py
@@ -1,18 +1,19 @@
 import os
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from langchain.agents import create_agent
-from langchain_core.tools import BaseTool
+from langchain_core.messages import AIMessage, ToolMessage
 from langchain_openai import ChatOpenAI
 
 from libsentrykube.prompts import SYSTEM_PROMPT, USER_PROMPT
+from libsentrykube.tools import build_tools
 
 DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
 DEFAULT_MODEL = "anthropic/claude-sonnet-4.5"
 
-# The tools the agent is given. Add them here.
-TOOLS: list[BaseTool] = []
+# Tool results can be whole rendered manifests. Only show the head of one.
+MAX_REPORTED_RESULT = 400
 
 
 class AgentConfigurationError(Exception):
@@ -46,11 +47,35 @@ def load_agent_config() -> AgentConfig:
     )
 
 
+@dataclass(frozen=True)
+class AgentStep:
+    """
+    Something the agent did, reported as it happens.
+
+    `kind` is one of:
+      - "thought": the agent reasoned about what to do next.
+      - "tool_call": the agent decided to call a tool. `tool` and `tool_input`
+        are set.
+      - "tool_result": a tool returned. `tool` and `detail` are set.
+    """
+
+    kind: str
+    message: str
+    tool: Optional[str] = None
+    tool_input: Optional[dict] = None
+    detail: Optional[str] = None
+
+
+# Called once per step while the agent works. See `AgentStep`.
+StepCallback = Callable[[AgentStep], None]
+
+
 def run_agent(
     query: str,
     region: str,
     cluster: Optional[str] = None,
     config: Optional[AgentConfig] = None,
+    on_step: Optional[StepCallback] = None,
 ) -> str:
     """
     Runs `query` through a langchain agent and returns the agent's response.
@@ -58,6 +83,9 @@ def run_agent(
     The prompts live in `libsentrykube.prompts`. `region` and `cluster` describe
     what the operator is working on and are rendered into the user prompt.
     `config` defaults to being read from the environment.
+
+    If `on_step` is given it is called with an `AgentStep` every time the agent
+    reasons or uses a tool, so callers can show progress while it works.
     """
     if config is None:
         config = load_agent_config()
@@ -70,15 +98,75 @@ def run_agent(
 
     agent = create_agent(
         model=model,
-        tools=TOOLS,
+        tools=build_tools(region, cluster),
         system_prompt=SYSTEM_PROMPT,
     )
 
     content = USER_PROMPT.format(query=query, region=region, cluster=cluster or "")
+    payload = {"messages": [{"role": "user", "content": content}]}
 
-    result = agent.invoke({"messages": [{"role": "user", "content": content}]})
+    if on_step is None:
+        result = agent.invoke(payload)
+        return _message_text(result["messages"][-1])
 
-    return _message_text(result["messages"][-1])
+    # Streaming so we can report each step. The last message the model produces
+    # is the answer, so hold on to it as we go.
+    answer = ""
+    for update in agent.stream(payload, stream_mode="updates"):
+        for node_update in update.values():
+            if not isinstance(node_update, dict):
+                continue
+            for message in node_update.get("messages", []):
+                text = _message_text(message)
+                for step in _steps_for(message, text):
+                    on_step(step)
+                if isinstance(message, AIMessage) and text:
+                    answer = text
+
+    return answer
+
+
+def _steps_for(message: Any, text: str) -> list[AgentStep]:
+    """
+    Turns one streamed message into the steps worth reporting.
+
+    A single model message can both reason and call tools, so this can return
+    more than one step.
+    """
+    steps = []
+
+    if isinstance(message, ToolMessage):
+        result = text.strip()
+        # The line count is of the whole result, so it stays honest even
+        # though `detail` only carries the head of it.
+        lines = len(result.splitlines())
+        detail = result
+        if len(detail) > MAX_REPORTED_RESULT:
+            detail = detail[:MAX_REPORTED_RESULT] + "..."
+        return [
+            AgentStep(
+                kind="tool_result",
+                message=f"{message.name} returned {lines} line(s)",
+                tool=message.name,
+                detail=detail,
+            )
+        ]
+
+    if isinstance(message, AIMessage):
+        if text.strip():
+            steps.append(AgentStep(kind="thought", message=text.strip()))
+        for call in message.tool_calls or []:
+            args = call.get("args") or {}
+            steps.append(
+                AgentStep(
+                    kind="tool_call",
+                    message=f"Calling {call['name']}",
+                    tool=call["name"],
+                    tool_input=args,
+                )
+            )
+
+    return steps
 
 
 def _message_text(message: Any) -> str:

--- a/libsentrykube/agent.py
+++ b/libsentrykube/agent.py
@@ -1,0 +1,98 @@
+import os
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+from langchain.agents import create_agent
+from langchain_core.tools import BaseTool
+from langchain_openai import ChatOpenAI
+
+
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_MODEL = "anthropic/claude-sonnet-4.5"
+
+
+class AgentConfigurationError(Exception):
+    """The agent is missing the configuration it needs to talk to the model."""
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+    model: str = DEFAULT_MODEL
+
+
+def load_agent_config() -> AgentConfig:
+    """
+    Builds the agent configuration from the environment.
+
+    OPENROUTER_API_KEY is required. OPENROUTER_BASE_URL is optional and defaults
+    to the public OpenRouter endpoint.
+    """
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        raise AgentConfigurationError(
+            "OPENROUTER_API_KEY is not set. Set it to your OpenRouter API key "
+            "(and optionally OPENROUTER_BASE_URL) to use the agent."
+        )
+
+    return AgentConfig(
+        api_key=api_key,
+        base_url=os.environ.get("OPENROUTER_BASE_URL") or DEFAULT_BASE_URL,
+    )
+
+
+def run_agent(
+    query: str,
+    system_prompt: Optional[str] = None,
+    tools: Optional[Sequence[BaseTool]] = None,
+    config: Optional[AgentConfig] = None,
+) -> str:
+    """
+    Runs `query` through a langchain agent and returns the agent's response.
+
+    `system_prompt` and `tools` are optional so callers can shape the agent
+    without this module knowing about them. `config` defaults to being read from
+    the environment.
+    """
+    if config is None:
+        config = load_agent_config()
+
+    model = ChatOpenAI(
+        model=config.model,
+        base_url=config.base_url,
+        api_key=config.api_key,
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=list(tools) if tools else [],
+        system_prompt=system_prompt,
+    )
+
+    result = agent.invoke({"messages": [{"role": "user", "content": query}]})
+
+    return _message_text(result["messages"][-1])
+
+
+def _message_text(message: Any) -> str:
+    """
+    Extracts the plain text out of a message.
+
+    `content` is usually a string, but it can also be a list of content blocks,
+    in which case we concatenate the text ones and drop the rest.
+    """
+    content = getattr(message, "content", message)
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "".join(parts)
+
+    return str(content)

--- a/libsentrykube/prompts.py
+++ b/libsentrykube/prompts.py
@@ -1,0 +1,19 @@
+"""
+Prompts used by the sentry-kube agent.
+
+USER_PROMPT is a `str.format` template. It is rendered with the `query`,
+`region` and `cluster` keywords, so those three placeholders have to stay
+present when the prompt is rewritten.
+"""
+
+SYSTEM_PROMPT = """\
+You are an assistant embedded in sentry-kube, the CLI Sentry uses to manage its
+Kubernetes production environments. Answer the operator's question.\
+"""
+
+USER_PROMPT = """\
+Region: {region}
+Cluster: {cluster}
+
+{query}\
+"""

--- a/libsentrykube/prompts.py
+++ b/libsentrykube/prompts.py
@@ -1,19 +1,58 @@
 """
 Prompts used by the sentry-kube agent.
 
-USER_PROMPT is a `str.format` template. It is rendered with the `query`,
-`region` and `cluster` keywords, so those three placeholders have to stay
-present when the prompt is rewritten.
+USER_PROMPT is a `str.format` template. It is rendered with the `query`
+keyword, so that placeholder has to stay present when the prompt is rewritten.
+
+The region and cluster are deliberately not in the prompt: they are bound to
+the tools in `libsentrykube.tools`, so the agent can only ever act on the
+region the operator chose on the command line.
 """
 
 SYSTEM_PROMPT = """\
-You are an assistant embedded in sentry-kube, the CLI Sentry uses to manage its
-Kubernetes production environments. Answer the operator's question.\
+You are a helpful production engineer that makes changes to our kubernetes manifests
+on behalf of the user who specifies what to do.
+
+This is the structure of our kubernetes manifests:
+- It all starts from the k8s root folder.
+- This contains a directory per service.
+- The service directory contains: multiple jinja templates, one _values.yaml file
+  that contains default values to fill the template, regional overrides in the
+  `regional_overrides folder.
+- The `regional_overrides` folder allows us to customize the manifest in a specific
+  region. These are the files you are going to touch.
+- When rendering a template we apply the values file first then the regional override
+  on top of it.
+
+Rules:
+- You are going to always work on one region at a time. The region is specified by the user.
+- You will only update the value file in the regional_overrides folder. You will not
+  update the templates for now.
+- You do not have tools to apply the changes in production. You can only render the manifests.
+- Yo uare not allowed to change sentry-kube code.
 """
 
 USER_PROMPT = """\
-Region: {region}
-Cluster: {cluster}
+Please make the changes to the value file that correspond to the user query below.
+Make the change in place, render the new manifest and return it to the user listing
+the files you touched.
 
-{query}\
+The procedure to make the change is as follows:
+1. Read the user query and understand the change required. Specifically identify
+   the service the user wants to change and the resource. You have tools to list
+   services and resources. Try to guess the service and resource if the user does
+   not spell them correctly. If you cannot identify them confidently, stop and
+   tell the user.
+2. Read the manifest for the service and identify the parameter you need to change
+   in the value file. You have a tool to read files from the service directory to
+   do so. If you cannot identify a parameter that matches the user query, stop
+   and tell the user.
+3. Find the path to the value in the regional override and apply the change. If the
+   value is not specified in the regional override, create the structure to hold
+   the value in the file.
+4. Render the new manifest for the resource to validate the change.
+
+You are operating on the {region} region in the {cluster} cluster.
+User query:
+{query}
 """

--- a/libsentrykube/tests/test_agent.py
+++ b/libsentrykube/tests/test_agent.py
@@ -1,13 +1,14 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from langchain_core.messages import AIMessage, ToolMessage
 
 from libsentrykube.agent import (
     DEFAULT_BASE_URL,
     DEFAULT_MODEL,
-    TOOLS,
     AgentConfig,
     AgentConfigurationError,
+    AgentStep,
     load_agent_config,
     run_agent,
 )
@@ -51,6 +52,7 @@ def test_run_agent() -> None:
     with (
         patch("libsentrykube.agent.ChatOpenAI") as mock_model,
         patch("libsentrykube.agent.create_agent") as mock_create_agent,
+        patch("libsentrykube.agent.build_tools") as mock_build_tools,
     ):
         mock_create_agent.return_value = _mock_agent("42")
 
@@ -68,9 +70,10 @@ def test_run_agent() -> None:
         base_url="https://example.com/v1",
         api_key="TEST_KEY",
     )
+    mock_build_tools.assert_called_once_with("us", "default")
     mock_create_agent.assert_called_once_with(
         model=mock_model.return_value,
-        tools=TOOLS,
+        tools=mock_build_tools.return_value,
         system_prompt=SYSTEM_PROMPT,
     )
     mock_create_agent.return_value.invoke.assert_called_once_with(
@@ -78,20 +81,19 @@ def test_run_agent() -> None:
             "messages": [
                 {
                     "role": "user",
-                    "content": USER_PROMPT.format(
-                        query="what is 6 times 7?", region="us", cluster="default"
-                    ),
+                    "content": USER_PROMPT.format(query="what is 6 times 7?"),
                 }
             ]
         }
     )
 
 
-def test_run_agent_query_region_and_cluster_reach_the_prompt() -> None:
-    """Whatever the prompt looks like, the three values must be rendered into it."""
+def test_run_agent_query_reaches_the_prompt() -> None:
+    """Whatever the prompt looks like, the query must be rendered into it."""
     with (
         patch("libsentrykube.agent.ChatOpenAI"),
         patch("libsentrykube.agent.create_agent") as mock_create_agent,
+        patch("libsentrykube.agent.build_tools"),
     ):
         mock_create_agent.return_value = _mock_agent("ok")
 
@@ -106,24 +108,28 @@ def test_run_agent_query_region_and_cluster_reach_the_prompt() -> None:
         "content"
     ]
     assert "why is it down?" in content
-    assert "s4s" in content
-    assert "primary" in content
 
 
-def test_run_agent_without_cluster() -> None:
-    """cluster is optional and must not leak a `None` into the prompt."""
+def test_run_agent_region_and_cluster_reach_the_tools() -> None:
+    """
+    Region and cluster are not in the prompt. They are bound to the tools so
+    the model cannot reach into a different region.
+    """
     with (
         patch("libsentrykube.agent.ChatOpenAI"),
         patch("libsentrykube.agent.create_agent") as mock_create_agent,
+        patch("libsentrykube.agent.build_tools") as mock_build_tools,
     ):
         mock_create_agent.return_value = _mock_agent("ok")
 
-        run_agent("hi", region="us", config=AgentConfig(api_key="TEST_KEY"))
+        run_agent(
+            "why is it down?",
+            region="s4s",
+            cluster="primary",
+            config=AgentConfig(api_key="TEST_KEY"),
+        )
 
-    content = mock_create_agent.return_value.invoke.call_args[0][0]["messages"][0][
-        "content"
-    ]
-    assert "None" not in content
+    mock_build_tools.assert_called_once_with("s4s", "primary")
 
 
 def test_run_agent_loads_config_from_env(monkeypatch) -> None:
@@ -133,6 +139,7 @@ def test_run_agent_loads_config_from_env(monkeypatch) -> None:
     with (
         patch("libsentrykube.agent.ChatOpenAI") as mock_model,
         patch("libsentrykube.agent.create_agent") as mock_create_agent,
+        patch("libsentrykube.agent.build_tools") as mock_build_tools,
     ):
         mock_create_agent.return_value = _mock_agent("hello")
 
@@ -141,8 +148,11 @@ def test_run_agent_loads_config_from_env(monkeypatch) -> None:
     mock_model.assert_called_once_with(
         model=DEFAULT_MODEL, base_url=DEFAULT_BASE_URL, api_key="ENV_KEY"
     )
+    mock_build_tools.assert_called_once_with("us", None)
     mock_create_agent.assert_called_once_with(
-        model=mock_model.return_value, tools=TOOLS, system_prompt=SYSTEM_PROMPT
+        model=mock_model.return_value,
+        tools=mock_build_tools.return_value,
+        system_prompt=SYSTEM_PROMPT,
     )
 
 
@@ -157,9 +167,171 @@ def test_run_agent_content_blocks() -> None:
     with (
         patch("libsentrykube.agent.ChatOpenAI"),
         patch("libsentrykube.agent.create_agent") as mock_create_agent,
+        patch("libsentrykube.agent.build_tools"),
     ):
         mock_create_agent.return_value = _mock_agent(content)
 
         response = run_agent("hi", region="us", config=AgentConfig(api_key="TEST_KEY"))
 
     assert response == "hello world"
+
+
+def _streaming_agent(updates) -> MagicMock:
+    agent = MagicMock()
+    agent.stream.return_value = iter(updates)
+    return agent
+
+
+def test_run_agent_reports_every_step() -> None:
+    """With on_step given, the agent streams and reports what it is doing."""
+    updates = [
+        {
+            "model": {
+                "messages": [
+                    AIMessage(
+                        content="Let me look at the service.",
+                        tool_calls=[
+                            {
+                                "name": "list_service_files",
+                                "args": {"service": "snuba"},
+                                "id": "1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    )
+                ]
+            }
+        },
+        {
+            "tools": {
+                "messages": [
+                    ToolMessage(
+                        content="deployment.yaml\n_values.yaml",
+                        name="list_service_files",
+                        tool_call_id="1",
+                    )
+                ]
+            }
+        },
+        {"model": {"messages": [AIMessage(content="Done, it has two files.")]}},
+    ]
+
+    steps: list[AgentStep] = []
+    with (
+        patch("libsentrykube.agent.ChatOpenAI"),
+        patch("libsentrykube.agent.create_agent") as mock_create_agent,
+        patch("libsentrykube.agent.build_tools"),
+    ):
+        mock_create_agent.return_value = _streaming_agent(updates)
+
+        response = run_agent(
+            "how many files?",
+            region="us",
+            config=AgentConfig(api_key="TEST_KEY"),
+            on_step=steps.append,
+        )
+
+    # The final model message is the answer, not the intermediate reasoning.
+    assert response == "Done, it has two files."
+
+    assert [step.kind for step in steps] == [
+        "thought",
+        "tool_call",
+        "tool_result",
+        "thought",
+    ]
+    assert steps[0].message == "Let me look at the service."
+    assert steps[1].tool == "list_service_files"
+    assert steps[1].tool_input == {"service": "snuba"}
+    assert steps[2].tool == "list_service_files"
+    assert "deployment.yaml" in (steps[2].detail or "")
+    # The count describes the whole result, not the truncated detail.
+    assert "2 line(s)" in steps[2].message
+
+
+def test_run_agent_reports_tool_call_without_reasoning() -> None:
+    """A model message can call a tool without saying anything first."""
+    updates = [
+        {
+            "model": {
+                "messages": [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "list_resources",
+                                "args": {"service": "snuba"},
+                                "id": "1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    )
+                ]
+            }
+        },
+    ]
+
+    steps: list[AgentStep] = []
+    with (
+        patch("libsentrykube.agent.ChatOpenAI"),
+        patch("libsentrykube.agent.create_agent") as mock_create_agent,
+        patch("libsentrykube.agent.build_tools"),
+    ):
+        mock_create_agent.return_value = _streaming_agent(updates)
+
+        run_agent(
+            "list them",
+            region="us",
+            config=AgentConfig(api_key="TEST_KEY"),
+            on_step=steps.append,
+        )
+
+    assert [step.kind for step in steps] == ["tool_call"]
+
+
+def test_run_agent_truncates_long_tool_results() -> None:
+    updates = [
+        {
+            "tools": {
+                "messages": [
+                    ToolMessage(
+                        content="x" * 5000, name="render_resource", tool_call_id="1"
+                    )
+                ]
+            }
+        },
+    ]
+
+    steps: list[AgentStep] = []
+    with (
+        patch("libsentrykube.agent.ChatOpenAI"),
+        patch("libsentrykube.agent.create_agent") as mock_create_agent,
+        patch("libsentrykube.agent.build_tools"),
+    ):
+        mock_create_agent.return_value = _streaming_agent(updates)
+
+        run_agent(
+            "render it",
+            region="us",
+            config=AgentConfig(api_key="TEST_KEY"),
+            on_step=steps.append,
+        )
+
+    detail = steps[0].detail or ""
+    assert len(detail) < 5000
+    assert detail.endswith("...")
+
+
+def test_run_agent_does_not_stream_without_a_callback() -> None:
+    """Without on_step the agent is invoked in one shot, as before."""
+    with (
+        patch("libsentrykube.agent.ChatOpenAI"),
+        patch("libsentrykube.agent.create_agent") as mock_create_agent,
+        patch("libsentrykube.agent.build_tools"),
+    ):
+        mock_create_agent.return_value = _mock_agent("42")
+
+        run_agent("hi", region="us", config=AgentConfig(api_key="TEST_KEY"))
+
+    mock_create_agent.return_value.stream.assert_not_called()
+    mock_create_agent.return_value.invoke.assert_called_once()

--- a/libsentrykube/tests/test_agent.py
+++ b/libsentrykube/tests/test_agent.py
@@ -1,0 +1,116 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from libsentrykube.agent import (
+    DEFAULT_BASE_URL,
+    DEFAULT_MODEL,
+    AgentConfig,
+    AgentConfigurationError,
+    load_agent_config,
+    run_agent,
+)
+
+
+def test_load_agent_config_defaults(monkeypatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "TEST_KEY")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    config = load_agent_config()
+
+    assert config == AgentConfig(
+        api_key="TEST_KEY", base_url=DEFAULT_BASE_URL, model=DEFAULT_MODEL
+    )
+
+
+def test_load_agent_config_custom_base_url(monkeypatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "TEST_KEY")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://example.com/v1")
+
+    assert load_agent_config().base_url == "https://example.com/v1"
+
+
+def test_load_agent_config_missing_key(monkeypatch) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    with pytest.raises(AgentConfigurationError, match="OPENROUTER_API_KEY"):
+        load_agent_config()
+
+
+def _mock_agent(content) -> MagicMock:
+    agent = MagicMock()
+    agent.invoke.return_value = {"messages": [MagicMock(content=content)]}
+    return agent
+
+
+def test_run_agent() -> None:
+    config = AgentConfig(api_key="TEST_KEY", base_url="https://example.com/v1")
+    tool = MagicMock()
+
+    with (
+        patch("libsentrykube.agent.ChatOpenAI") as mock_model,
+        patch("libsentrykube.agent.create_agent") as mock_create_agent,
+    ):
+        mock_create_agent.return_value = _mock_agent("42")
+
+        response = run_agent(
+            "what is 6 times 7?",
+            system_prompt="be terse",
+            tools=[tool],
+            config=config,
+        )
+
+    assert response == "42"
+
+    mock_model.assert_called_once_with(
+        model=DEFAULT_MODEL,
+        base_url="https://example.com/v1",
+        api_key="TEST_KEY",
+    )
+    mock_create_agent.assert_called_once_with(
+        model=mock_model.return_value,
+        tools=[tool],
+        system_prompt="be terse",
+    )
+    mock_create_agent.return_value.invoke.assert_called_once_with(
+        {"messages": [{"role": "user", "content": "what is 6 times 7?"}]}
+    )
+
+
+def test_run_agent_loads_config_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "ENV_KEY")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    with (
+        patch("libsentrykube.agent.ChatOpenAI") as mock_model,
+        patch("libsentrykube.agent.create_agent") as mock_create_agent,
+    ):
+        mock_create_agent.return_value = _mock_agent("hello")
+
+        assert run_agent("hi") == "hello"
+
+    mock_model.assert_called_once_with(
+        model=DEFAULT_MODEL, base_url=DEFAULT_BASE_URL, api_key="ENV_KEY"
+    )
+    mock_create_agent.assert_called_once_with(
+        model=mock_model.return_value, tools=[], system_prompt=None
+    )
+
+
+def test_run_agent_content_blocks() -> None:
+    """The model can return a list of content blocks instead of a plain string."""
+    content = [
+        {"type": "text", "text": "hello "},
+        {"type": "thinking", "thinking": "dropped"},
+        {"type": "text", "text": "world"},
+    ]
+
+    with (
+        patch("libsentrykube.agent.ChatOpenAI"),
+        patch("libsentrykube.agent.create_agent") as mock_create_agent,
+    ):
+        mock_create_agent.return_value = _mock_agent(content)
+
+        response = run_agent("hi", config=AgentConfig(api_key="TEST_KEY"))
+
+    assert response == "hello world"

--- a/libsentrykube/tests/test_agent.py
+++ b/libsentrykube/tests/test_agent.py
@@ -5,11 +5,13 @@ import pytest
 from libsentrykube.agent import (
     DEFAULT_BASE_URL,
     DEFAULT_MODEL,
+    TOOLS,
     AgentConfig,
     AgentConfigurationError,
     load_agent_config,
     run_agent,
 )
+from libsentrykube.prompts import SYSTEM_PROMPT, USER_PROMPT
 
 
 def test_load_agent_config_defaults(monkeypatch) -> None:
@@ -45,7 +47,6 @@ def _mock_agent(content) -> MagicMock:
 
 def test_run_agent() -> None:
     config = AgentConfig(api_key="TEST_KEY", base_url="https://example.com/v1")
-    tool = MagicMock()
 
     with (
         patch("libsentrykube.agent.ChatOpenAI") as mock_model,
@@ -55,8 +56,8 @@ def test_run_agent() -> None:
 
         response = run_agent(
             "what is 6 times 7?",
-            system_prompt="be terse",
-            tools=[tool],
+            region="us",
+            cluster="default",
             config=config,
         )
 
@@ -69,12 +70,60 @@ def test_run_agent() -> None:
     )
     mock_create_agent.assert_called_once_with(
         model=mock_model.return_value,
-        tools=[tool],
-        system_prompt="be terse",
+        tools=TOOLS,
+        system_prompt=SYSTEM_PROMPT,
     )
     mock_create_agent.return_value.invoke.assert_called_once_with(
-        {"messages": [{"role": "user", "content": "what is 6 times 7?"}]}
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": USER_PROMPT.format(
+                        query="what is 6 times 7?", region="us", cluster="default"
+                    ),
+                }
+            ]
+        }
     )
+
+
+def test_run_agent_query_region_and_cluster_reach_the_prompt() -> None:
+    """Whatever the prompt looks like, the three values must be rendered into it."""
+    with (
+        patch("libsentrykube.agent.ChatOpenAI"),
+        patch("libsentrykube.agent.create_agent") as mock_create_agent,
+    ):
+        mock_create_agent.return_value = _mock_agent("ok")
+
+        run_agent(
+            "why is it down?",
+            region="s4s",
+            cluster="primary",
+            config=AgentConfig(api_key="TEST_KEY"),
+        )
+
+    content = mock_create_agent.return_value.invoke.call_args[0][0]["messages"][0][
+        "content"
+    ]
+    assert "why is it down?" in content
+    assert "s4s" in content
+    assert "primary" in content
+
+
+def test_run_agent_without_cluster() -> None:
+    """cluster is optional and must not leak a `None` into the prompt."""
+    with (
+        patch("libsentrykube.agent.ChatOpenAI"),
+        patch("libsentrykube.agent.create_agent") as mock_create_agent,
+    ):
+        mock_create_agent.return_value = _mock_agent("ok")
+
+        run_agent("hi", region="us", config=AgentConfig(api_key="TEST_KEY"))
+
+    content = mock_create_agent.return_value.invoke.call_args[0][0]["messages"][0][
+        "content"
+    ]
+    assert "None" not in content
 
 
 def test_run_agent_loads_config_from_env(monkeypatch) -> None:
@@ -87,13 +136,13 @@ def test_run_agent_loads_config_from_env(monkeypatch) -> None:
     ):
         mock_create_agent.return_value = _mock_agent("hello")
 
-        assert run_agent("hi") == "hello"
+        assert run_agent("hi", region="us") == "hello"
 
     mock_model.assert_called_once_with(
         model=DEFAULT_MODEL, base_url=DEFAULT_BASE_URL, api_key="ENV_KEY"
     )
     mock_create_agent.assert_called_once_with(
-        model=mock_model.return_value, tools=[], system_prompt=None
+        model=mock_model.return_value, tools=TOOLS, system_prompt=SYSTEM_PROMPT
     )
 
 
@@ -111,6 +160,6 @@ def test_run_agent_content_blocks() -> None:
     ):
         mock_create_agent.return_value = _mock_agent(content)
 
-        response = run_agent("hi", config=AgentConfig(api_key="TEST_KEY"))
+        response = run_agent("hi", region="us", config=AgentConfig(api_key="TEST_KEY"))
 
     assert response == "hello world"

--- a/libsentrykube/tests/test_tools.py
+++ b/libsentrykube/tests/test_tools.py
@@ -1,0 +1,248 @@
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from libsentrykube.context import init_cluster_context
+from libsentrykube.service import get_service_path, get_service_value_override_path
+from libsentrykube.tools import ToolError, build_tools
+
+REGION = "saas"
+CLUSTER = "customer"
+
+
+@pytest.fixture
+def tools():
+    init_cluster_context(REGION, CLUSTER)
+    return {tool.name: tool for tool in build_tools(REGION, CLUSTER)}
+
+
+def _invoke(tool, **kwargs) -> str:
+    """Calls a tool the way the agent does, through its schema."""
+    return tool.invoke(kwargs)
+
+
+def test_build_tools_exposes_every_tool(tools) -> None:
+    assert set(tools) == {
+        "list_service_files",
+        "read_service_file",
+        "list_resources",
+        "render_resource",
+        "read_region_override",
+        "update_region_override",
+    }
+
+
+def test_list_service_files(tools) -> None:
+    output = _invoke(tools["list_service_files"], service="service1")
+
+    files = output.splitlines()
+    assert "deployment.yaml" in files
+    assert "_values.yaml" in files
+    # Nested override files are reachable too.
+    assert "region_overrides/us/customer.yaml" in files
+
+
+def test_list_service_files_unknown_service(tools) -> None:
+    with pytest.raises(ToolError, match="no service named 'nope'"):
+        _invoke(tools["list_service_files"], service="nope")
+
+
+def test_read_service_file(tools) -> None:
+    output = _invoke(
+        tools["read_service_file"], service="service1", path="_values.yaml"
+    )
+
+    assert output == (get_service_path("service1") / "_values.yaml").read_text()
+
+
+def test_read_service_file_rejects_traversal(tools) -> None:
+    with pytest.raises(ToolError, match="outside of"):
+        _invoke(
+            tools["read_service_file"],
+            service="service1",
+            path="../service2/deployment.yaml",
+        )
+
+
+def test_read_service_file_rejects_absolute_path(tools) -> None:
+    with pytest.raises(ToolError, match="outside of"):
+        _invoke(tools["read_service_file"], service="service1", path="/etc/passwd")
+
+
+def test_read_service_file_rejects_other_file_types(tools, tmp_path) -> None:
+    secret = get_service_path("service1") / "secret.txt"
+    secret.write_text("nope")
+    try:
+        with pytest.raises(ToolError, match="not a readable file type"):
+            _invoke(tools["read_service_file"], service="service1", path="secret.txt")
+    finally:
+        secret.unlink()
+
+
+def test_read_service_file_missing(tools) -> None:
+    with pytest.raises(ToolError, match="does not exist"):
+        _invoke(tools["read_service_file"], service="service1", path="nope.yaml")
+
+
+# The fixture services render to nothing, so rendering is exercised against a
+# stubbed render_templates. What matters here is that the tools bind the right
+# region/cluster and post-process the manifest correctly.
+RENDERED = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+"""
+
+
+def test_list_resources(tools) -> None:
+    with patch("libsentrykube.tools.render_templates") as mock_render:
+        mock_render.return_value = RENDERED
+
+        output = _invoke(tools["list_resources"], service="service1")
+
+    assert output.splitlines() == ["Deployment/my-deployment", "Service/my-service"]
+    # The region and cluster are the ones the tools were built with, not
+    # anything the model supplied.
+    mock_render.assert_called_once_with(REGION, "service1", CLUSTER)
+
+
+def test_list_resources_unknown_service(tools) -> None:
+    with pytest.raises(ToolError, match="no service named 'nope'"):
+        _invoke(tools["list_resources"], service="nope")
+
+
+def test_list_resources_render_failure(tools) -> None:
+    with patch("libsentrykube.tools.render_templates") as mock_render:
+        mock_render.side_effect = ValueError("undefined variable")
+
+        with pytest.raises(ToolError, match="Could not render"):
+            _invoke(tools["list_resources"], service="service1")
+
+
+def test_render_resource(tools) -> None:
+    with patch("libsentrykube.tools.render_templates") as mock_render:
+        # render_templates filters, so it only returns the requested document.
+        mock_render.return_value = RENDERED.split("---")[0]
+
+        output = _invoke(
+            tools["render_resource"], service="service1", resource_name="my-deployment"
+        )
+
+    document = yaml.safe_load(output)
+    assert document["kind"] == "Deployment"
+    assert document["metadata"]["name"] == "my-deployment"
+    mock_render.assert_called_once_with(
+        REGION, "service1", CLUSTER, filters=["metadata.name=my-deployment"]
+    )
+
+
+def test_render_resource_unknown_name(tools) -> None:
+    with patch("libsentrykube.tools.render_templates") as mock_render:
+        # Everything was filtered out, leaving empty documents behind.
+        mock_render.return_value = "\n---\n"
+
+        with pytest.raises(ToolError, match="no resource named 'nope'"):
+            _invoke(tools["render_resource"], service="service1", resource_name="nope")
+
+
+def test_read_region_override(tools) -> None:
+    output = _invoke(
+        tools["read_region_override"], service="service1", file_name="customer.yaml"
+    )
+
+    expected = get_service_value_override_path("service1", REGION) / "customer.yaml"
+    assert output == expected.read_text()
+
+
+def test_read_region_override_missing_lists_what_exists(tools) -> None:
+    with pytest.raises(ToolError, match="customer.yaml"):
+        _invoke(
+            tools["read_region_override"], service="service1", file_name="nope.yaml"
+        )
+
+
+def test_update_region_override(tools) -> None:
+    target = get_service_value_override_path("service1", REGION) / "agent_test.yaml"
+    try:
+        result = _invoke(
+            tools["update_region_override"],
+            service="service1",
+            file_name="agent_test.yaml",
+            content="key: value\n",
+        )
+
+        assert "agent_test.yaml" in result
+        assert target.read_text() == "key: value\n"
+    finally:
+        target.unlink(missing_ok=True)
+
+
+def test_update_region_override_rejects_invalid_yaml(tools) -> None:
+    target = get_service_value_override_path("service1", REGION) / "agent_test.yaml"
+
+    with pytest.raises(ToolError, match="not valid yaml"):
+        _invoke(
+            tools["update_region_override"],
+            service="service1",
+            file_name="agent_test.yaml",
+            content="key: [unclosed\n",
+        )
+
+    assert not target.exists()
+
+
+def test_update_region_override_rejects_traversal(tools) -> None:
+    with pytest.raises(ToolError, match="outside of"):
+        _invoke(
+            tools["update_region_override"],
+            service="service1",
+            file_name="../../_values.yaml",
+            content="key: value\n",
+        )
+
+
+def test_update_region_override_rejects_subdirectory(tools) -> None:
+    with pytest.raises(ToolError, match="not in a subdirectory"):
+        _invoke(
+            tools["update_region_override"],
+            service="service1",
+            file_name="nested/file.yaml",
+            content="key: value\n",
+        )
+
+
+def test_update_region_override_rejects_non_yaml(tools) -> None:
+    with pytest.raises(ToolError, match="must be a yaml file"):
+        _invoke(
+            tools["update_region_override"],
+            service="service1",
+            file_name="notes.txt",
+            content="key: value\n",
+        )
+
+
+def test_tools_are_scoped_to_the_bound_region() -> None:
+    """A tool built for one region must not write into another one."""
+    init_cluster_context(REGION, CLUSTER)
+    tools = {tool.name: tool for tool in build_tools(REGION, CLUSTER)}
+
+    target = get_service_value_override_path("service1", REGION) / "agent_test.yaml"
+    try:
+        _invoke(
+            tools["update_region_override"],
+            service="service1",
+            file_name="agent_test.yaml",
+            content="key: value\n",
+        )
+        # The write landed under the region the tools were built for, and the
+        # agent had no way to name a different one.
+        assert target.exists()
+    finally:
+        target.unlink(missing_ok=True)

--- a/libsentrykube/tools.py
+++ b/libsentrykube/tools.py
@@ -1,0 +1,280 @@
+"""
+The tools the sentry-kube agent is given.
+
+Every tool is scoped to a single service directory, resolved through
+`libsentrykube.service.get_service_path`, and refuses to touch anything outside
+of it. Writes are further restricted to the region override directory of the
+region the CLI is operating on.
+"""
+
+from pathlib import Path
+from typing import Any, Optional
+
+import click
+import yaml
+from langchain_core.tools import BaseTool, tool
+
+from libsentrykube.kube import render_templates
+from libsentrykube.service import (
+    get_service_names,
+    get_service_path,
+    get_service_value_override_path,
+)
+
+# What the agent is allowed to read out of a service directory.
+READABLE_SUFFIXES = (".yaml", ".yml", ".j2", ".jinja", ".jinja2")
+
+# What the agent is allowed to write into a region override directory.
+WRITABLE_SUFFIXES = (".yaml", ".yml")
+
+
+class ToolError(Exception):
+    """
+    A tool was asked to do something it will not do.
+
+    The message is handed back to the model so it can correct itself, so it
+    should say what went wrong and what the valid options are.
+    """
+
+
+def _resolve_service_path(service: str) -> Path:
+    """
+    Returns the directory of `service`, or raises if there is no such service.
+    """
+    try:
+        return get_service_path(service).resolve()
+    except click.Abort:
+        raise ToolError(
+            f"There is no service named '{service}'. "
+            f"Available services: {', '.join(sorted(get_service_names()))}"
+        )
+
+
+def _resolve_within(root: Path, relative_path: str) -> Path:
+    """
+    Resolves `relative_path` against `root` and asserts it stayed inside it.
+
+    This is what stops `../../` and absolute paths from escaping the service
+    directory.
+    """
+    candidate = (root / relative_path).resolve()
+    if candidate != root and root not in candidate.parents:
+        raise ToolError(
+            f"'{relative_path}' is outside of {root.name}, which is not allowed."
+        )
+    return candidate
+
+
+def _resource_names(rendered: str) -> list[str]:
+    """
+    Pulls every `metadata.name` out of a rendered multi document manifest.
+    """
+    names = []
+    for doc in yaml.safe_load_all(rendered):
+        if not doc:
+            continue
+        name = (doc.get("metadata") or {}).get("name")
+        if name:
+            names.append(f"{doc.get('kind', 'Unknown')}/{name}")
+    return names
+
+
+def build_tools(region: str, cluster: Optional[str] = None) -> list[BaseTool]:
+    """
+    Builds the tools for one agent run.
+
+    `region` and `cluster` are bound here rather than being tool arguments: the
+    operator already chose them on the command line, and the agent must not be
+    able to reach into a different region.
+    """
+    cluster_name = cluster or "default"
+
+    @tool
+    def list_service_files(service: str) -> str:
+        """List the template and yaml files that make up a service.
+
+        Use this to discover what a service is built from before reading
+        anything. Returns one path per line, relative to the service directory.
+
+        Args:
+            service: Name of the service, for example 'snuba'.
+        """
+        root = _resolve_service_path(service)
+
+        paths = sorted(
+            str(path.relative_to(root))
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix in READABLE_SUFFIXES
+        )
+        if not paths:
+            return f"Service '{service}' has no template or yaml files."
+        return "\n".join(paths)
+
+    @tool
+    def read_service_file(service: str, path: str) -> str:
+        """Read one template or yaml file belonging to a service.
+
+        Only files inside the service directory can be read. Use
+        list_service_files first to find out which paths exist.
+
+        Args:
+            service: Name of the service, for example 'snuba'.
+            path: Path of the file relative to the service directory.
+        """
+        root = _resolve_service_path(service)
+        target = _resolve_within(root, path)
+
+        if target.suffix not in READABLE_SUFFIXES:
+            raise ToolError(
+                f"'{path}' is not a readable file type. "
+                f"Readable types: {', '.join(READABLE_SUFFIXES)}"
+            )
+        if not target.is_file():
+            raise ToolError(f"'{path}' does not exist in service '{service}'.")
+
+        return target.read_text()
+
+    @tool
+    def list_resources(service: str) -> str:
+        """List the Kubernetes resources a service renders to.
+
+        Renders the service for the region and cluster currently being operated
+        on and returns one 'Kind/name' per line. Use this to pick a resource
+        before rendering it in full.
+
+        Args:
+            service: Name of the service, for example 'snuba'.
+        """
+        # Fail early with a useful message rather than deep inside jinja.
+        _resolve_service_path(service)
+
+        try:
+            rendered = render_templates(region, service, cluster_name)
+        except Exception as e:
+            raise ToolError(f"Could not render service '{service}': {e}")
+
+        names = _resource_names(rendered)
+        if not names:
+            return f"Service '{service}' renders no resources."
+        return "\n".join(names)
+
+    @tool
+    def render_resource(service: str, resource_name: str) -> str:
+        """Render a single Kubernetes resource of a service to yaml.
+
+        Rendering a whole service produces far too much output, so this renders
+        only the named resource. Get the name from list_resources first, and
+        pass just the name, without the 'Kind/' prefix.
+
+        Args:
+            service: Name of the service, for example 'snuba'.
+            resource_name: The metadata.name of the resource to render.
+        """
+        _resolve_service_path(service)
+
+        try:
+            rendered = render_templates(
+                region,
+                service,
+                cluster_name,
+                filters=[f"metadata.name={resource_name}"],
+            )
+        except Exception as e:
+            raise ToolError(f"Could not render service '{service}': {e}")
+
+        # Filtered out templates still render as empty documents.
+        documents = [doc for doc in yaml.safe_load_all(rendered) if doc]
+        if not documents:
+            raise ToolError(
+                f"Service '{service}' has no resource named '{resource_name}'. "
+                f"Use list_resources to see what is available."
+            )
+
+        return yaml.dump_all(documents, default_flow_style=False)
+
+    @tool
+    def read_region_override(service: str, file_name: str) -> str:
+        """Read one of the region override files of a service.
+
+        Reads from the override directory of the region currently being
+        operated on. Read the file before updating it so the update keeps the
+        values that should not change.
+
+        Args:
+            service: Name of the service, for example 'snuba'.
+            file_name: Name of the override file, for example 'default.yaml'.
+        """
+        target = _region_override_file(service, file_name)
+
+        if not target.is_file():
+            existing = _list_region_overrides(service)
+            raise ToolError(
+                f"'{file_name}' does not exist for service '{service}' in region "
+                f"'{region}'. Existing override files: {existing}"
+            )
+
+        return target.read_text()
+
+    @tool
+    def update_region_override(service: str, file_name: str, content: str) -> str:
+        """Overwrite one of the region override files of a service.
+
+        Writes to the override directory of the region currently being operated
+        on, and nowhere else. `content` replaces the whole file, so read the
+        file first and send it back with your changes applied. Comments in the
+        existing file are not preserved unless you include them in `content`.
+
+        Args:
+            service: Name of the service, for example 'snuba'.
+            file_name: Name of the override file, for example 'default.yaml'.
+            content: The full new yaml content of the file.
+        """
+        target = _region_override_file(service, file_name)
+
+        try:
+            yaml.safe_load(content)
+        except yaml.YAMLError as e:
+            raise ToolError(f"The content is not valid yaml, nothing was written: {e}")
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+
+        return f"Wrote {target}."
+
+    def _region_override_file(service: str, file_name: str) -> Path:
+        """
+        Resolves an override file name inside the region override directory.
+        """
+        # Raises if the service does not exist.
+        _resolve_service_path(service)
+
+        override_root = get_service_value_override_path(service, region).resolve()
+        target = _resolve_within(override_root, file_name)
+
+        if target.parent != override_root:
+            raise ToolError(
+                f"'{file_name}' must be a file directly in the region override "
+                f"directory, not in a subdirectory."
+            )
+        if target.suffix not in WRITABLE_SUFFIXES:
+            raise ToolError(
+                f"'{file_name}' must be a yaml file ({', '.join(WRITABLE_SUFFIXES)})."
+            )
+        return target
+
+    def _list_region_overrides(service: str) -> str:
+        override_root = get_service_value_override_path(service, region)
+        if not override_root.is_dir():
+            return "none"
+        names = sorted(path.name for path in override_root.iterdir() if path.is_file())
+        return ", ".join(names) if names else "none"
+
+    tools: list[Any] = [
+        list_service_files,
+        read_service_file,
+        list_resources,
+        render_resource,
+        read_region_override,
+        update_region_override,
+    ]
+    return tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
---index-url https://pypi.devinfra.sentry.io/simple
+# TODO: restore before merging. langchain/langchain-openai are not mirrored on
+# pypi.devinfra.sentry.io yet, so during development we resolve from public PyPI.
+# --index-url https://pypi.devinfra.sentry.io/simple
 
 click>=8.1.7
 dictdiffer>=0.9.0
@@ -11,6 +13,8 @@ jsonpatch>=1.33
 jsonpath_ng>=1.6.1
 jsonschema>=4.23.0
 kubernetes>=30.1.0
+langchain>=1.0.0
+langchain-openai>=1.0.0
 paramiko>=3.4.0
 protobuf>=5.28.1
 PyYAML>=6.0.1

--- a/sentry_kube/cli/agent.py
+++ b/sentry_kube/cli/agent.py
@@ -1,0 +1,21 @@
+import click
+from libsentrykube.agent import AgentConfigurationError
+from libsentrykube.agent import run_agent
+from libsentrykube.utils import die
+
+__all__ = ("agent",)
+
+
+@click.command()
+@click.argument("query", type=str)
+@click.pass_context
+def agent(ctx: click.core.Context, query: str) -> None:
+    """
+    Ask the sentry-kube AI agent a question.
+    """
+    try:
+        response = run_agent(query)
+    except AgentConfigurationError as e:
+        die(str(e))
+    else:
+        click.echo(response)

--- a/sentry_kube/cli/agent.py
+++ b/sentry_kube/cli/agent.py
@@ -1,15 +1,59 @@
 import click
 from libsentrykube.agent import AgentConfigurationError
+from libsentrykube.agent import AgentStep
 from libsentrykube.agent import run_agent
 from libsentrykube.utils import die
 
 __all__ = ("agent",)
 
+# How much of a tool's arguments to show on the step line.
+MAX_REPORTED_ARGS = 120
+
+
+def _format_args(tool_input: dict) -> str:
+    parts = []
+    for key, value in tool_input.items():
+        text = str(value).replace("\n", " ")
+        if len(text) > 40:
+            text = text[:40] + "..."
+        parts.append(f"{key}={text}")
+
+    joined = ", ".join(parts)
+    if len(joined) > MAX_REPORTED_ARGS:
+        joined = joined[:MAX_REPORTED_ARGS] + "..."
+    return joined
+
+
+def _echo_step(step: AgentStep) -> None:
+    """
+    Prints one step of the agent's work to stderr.
+
+    Progress goes to stderr so that piping the command still gives you just the
+    agent's answer on stdout.
+    """
+    if step.kind == "thought":
+        click.secho(f"* {step.message}", fg="cyan", err=True)
+    elif step.kind == "tool_call":
+        args = _format_args(step.tool_input or {})
+        click.secho(f"  -> {step.tool}({args})", fg="yellow", err=True)
+    elif step.kind == "tool_result":
+        first_line = (step.detail or "").splitlines()
+        summary = first_line[0] if first_line else "(no output)"
+        if len(summary) > 60:
+            summary = summary[:60] + "..."
+        click.secho(f"  <- {step.message}: {summary}", fg="green", err=True)
+
 
 @click.command()
 @click.argument("query", type=str)
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    help="Only print the final answer, not what the agent is doing.",
+)
 @click.pass_context
-def agent(ctx: click.core.Context, query: str) -> None:
+def agent(ctx: click.core.Context, query: str, quiet: bool) -> None:
     """
     Ask the sentry-kube AI agent a question.
     """
@@ -18,8 +62,11 @@ def agent(ctx: click.core.Context, query: str) -> None:
             query,
             region=ctx.obj.customer_name,
             cluster=ctx.obj.cluster_name,
+            on_step=None if quiet else _echo_step,
         )
     except AgentConfigurationError as e:
         die(str(e))
     else:
+        if not quiet:
+            click.echo("", err=True)
         click.echo(response)

--- a/sentry_kube/cli/agent.py
+++ b/sentry_kube/cli/agent.py
@@ -14,7 +14,11 @@ def agent(ctx: click.core.Context, query: str) -> None:
     Ask the sentry-kube AI agent a question.
     """
     try:
-        response = run_agent(query)
+        response = run_agent(
+            query,
+            region=ctx.obj.customer_name,
+            cluster=ctx.obj.cluster_name,
+        )
     except AgentConfigurationError as e:
         die(str(e))
     else:


### PR DESCRIPTION
PoC: Adding an agent in sentry kube to help people make more catastriphic mistakes 
quicker .... ehm ... make simple value files changes quicker. 

The idea is that hte agent understands the structure of sentry-kube manifests,
it has tools to read services, render templates and make changes to value
files. 
It can take a plan text description of the change and apply that.

The altenraive option is to embed this into claude give it a skill 
to understand the ops repo and give it a tool to run
sentry-kube render. Which would basically be a portion of this PR.
